### PR TITLE
replace pbspan with ptfarea

### DIFF
--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -815,7 +815,7 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                 for infomesh in infolist:
                     if infomesh['needs_mesh'] and infomesh['kind'] != 'mesh':
                         new_syns.set_value(qualifier='pblum', time=time, dataset=infomesh['dataset'], component=info['component'], kind='mesh', value=body.compute_luminosity(infomesh['dataset']))
-                        new_syns.set_value(qualifier='pbspan', time=time, dataset=infomesh['dataset'], component=info['component'], kind='mesh', value=body.get_pbspan(infomesh['dataset']))
+                        new_syns.set_value(qualifier='ptfarea', time=time, dataset=infomesh['dataset'], component=info['component'], kind='mesh', value=body.get_ptfarea(infomesh['dataset']))
 
                         for indep in indeps[infomesh['kind']]:
                             key = "{}:{}".format(indep, infomesh['dataset'])

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -422,7 +422,7 @@ def mesh_syn(syn=True, **kwargs):
                     if kind in ['lc', 'rv']:
                         syn_params += [FloatParameter(qualifier='pblum', dataset=dataset, time=t, value=kwargs.get('pblum', 0.0), default_unit=u.W, description='Passband Luminosity of entire star')]
                         syn_params += [FloatArrayParameter(qualifier='ldint', dataset=dataset, time=t, value=kwargs.get('ldint', []), default_unit=u.dimensionless_unscaled, description='Integral of the limb-darkening function')]
-                        syn_params += [FloatParameter(qualifier='pbspan', dataset=dataset, time=t, value=kwargs.get('pbspan', 1.0), default_unit=u.m, description='Wavelength span of the passband')]
+                        syn_params += [FloatParameter(qualifier='ptfarea', dataset=dataset, time=t, value=kwargs.get('ptfarea', 1.0), default_unit=u.m, description='Area of the passband transmission function')]
 
                     for indep, default_unit in indeps.items():
                         syn_params += [FloatArrayParameter(indep, dataset=dataset, time=t, value=[], default_unit=default_unit, description='Per-element value for {} dataset'.format(dataset))]


### PR DESCRIPTION
Definition of flux and luminosity now use ptfarea instead of pbspan.  In the bolometric case, these give the same quantity.  This discrepancy was absorbed entirely by pblum scaling, so relative fluxes should not be affected, but the underlying absolute luminosities were incorrect for passbands (non-bolometric).

In addition to under-the-hood changes, the exposed mesh column for 'pbspan' is now removed and replaced with 'ptfarea'.