### PR TITLE
re-design for the way passband columns in mesh datasets are handled

### DIFF
--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -1466,12 +1466,12 @@ def photodynam(b, compute, times=[], **kwargs):
         elif info['kind']=='orb':
             cind = starrefs.index(info['component'])
             this_syn['times'] = stuff[0] * u.d
-            this_syn['xs'] = -1*stuff[2+(cind*3)] * u.AU
-            this_syn['ys'] = -1*stuff[3+(cind*3)] * u.AU
-            this_syn['zs'] = stuff[4+(cind*3)] * u.AU
-            this_syn['vxs'] = -1*stuff[3*nbodies+2+(cind*3)] * u.AU/u.d
-            this_syn['vys'] = -1*stuff[3*nbodies+3+(cind*3)] * u.AU/u.d
-            this_syn['vzs'] = stuff[3*nbodies+4+(cind*3)] * u.AU/u.d
+            this_syn['us'] = -1*stuff[2+(cind*3)] * u.AU
+            this_syn['vs'] = -1*stuff[3+(cind*3)] * u.AU
+            this_syn['ws'] = stuff[4+(cind*3)] * u.AU
+            this_syn['vus'] = -1*stuff[3*nbodies+2+(cind*3)] * u.AU/u.d
+            this_syn['vvs'] = -1*stuff[3*nbodies+3+(cind*3)] * u.AU/u.d
+            this_syn['vws'] = stuff[3*nbodies+4+(cind*3)] * u.AU/u.d
         elif info['kind']=='rv':
             cind = starrefs.index(info['component'])
             this_syn['times'] = stuff[0] * u.d

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -131,6 +131,15 @@ def _extract_from_bundle_by_time(b, compute, times=None, allow_oversample=False,
             except ValueError: #TODO: custom exception for no parameter
                 continue
 
+            if obs_ps.kind == 'mesh':
+                # then we also have the ability to append times from another dataset
+                for add_dataset in obs_ps.get_value(qualifier='include_times'):
+                    logger.info("including times from '{}' in '{}'".format(add_dataset, dataset))
+                    add_ps = b.filter(dataset=add_dataset, context='dataset')
+                    add_timequalifier = _timequalifier_by_kind(add_ps.kind)
+                    add_times = add_ps.get_value(qualifier=add_timequalifier, component=component, unit=u.d)
+                    this_times = np.append(this_times, add_times)
+
             if len(this_times) and provided_times is not None:
                 # then overrride the dataset times with the passed times
                 #  (as kwarg to run_compute)
@@ -240,6 +249,15 @@ def _extract_from_bundle_by_dataset(b, compute, times=[]):
                 this_times = obs_ps.get_value(qualifier=timequalifier, component=component, unit=u.d)
             except ValueError: #TODO: custom exception for no parameter
                 continue
+
+            if obs_ps.kind == 'mesh':
+                # then we also have the ability to append times from another dataset
+                for add_dataset in obs_ps.get_value(qualifier='include_times'):
+                    logger.info("including times from '{}' in '{}'".format(add_dataset, dataset))
+                    add_ps = b.filter(dataset=add_dataset, context='dataset')
+                    add_timequalifier = _timequalifier_by_kind(add_ps.kind)
+                    add_times = add_ps.get_value(qualifier=add_timequalifier, component=component, unit=u.d)
+                    this_times = np.append(this_times, add_times)
 
             # if not len(this_times):
                 # then override with passed times if available

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -332,7 +332,8 @@ def _create_syns(b, needed_syns):
             # needed_syn['dataset_fields'] = needs_mesh
 
             needed_syn['columns'] = b.get_value(qualifier='columns', dataset=needed_syn['dataset'], context='dataset')
-            needed_syn['datasets'] = b.get_value(qualifier='datasets', dataset=needed_syn['dataset'], context='dataset')
+            datasets = b.get_value(qualifier='datasets', dataset=needed_syn['dataset'], context='dataset')
+            needed_syn['datasets'] = {ds: b.filter(datset=ds, context='dataset').exclude(kind='*_dep').kind for ds in datasets}
 
         # phoebe will compute everything sorted - even if the input times array
         # is out of order, so let's make sure the exposed times array is in
@@ -803,7 +804,12 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
 
                             if indep in info['columns']:
                                 key = "{}:{}".format(indep, infomesh['dataset'])
-                                packet[k]['PBCOLUMN'] += [{'qualifier': indep, 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.mesh[key].centers}]
+
+                                if indep=='rvs' and infomesh['kind'] != 'rv':
+                                    continue
+                                else:
+                                    value = body.mesh[key].centers
+                                    packet[k]['PBCOLUMN'] += [{'qualifier': indep, 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': value}]
 
             else:
                 raise NotImplementedError("kind {} not yet supported by this backend".format(kind))

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -156,9 +156,9 @@ def _extract_from_bundle(b, compute, times=None, allow_oversample=False,
     # now have their own entries.)
 
     for dataset in b.filter(qualifier='enabled', compute=compute, value=True).datasets:
-        dataset_ps = b.filter(context='dataset', dataset=dataset).exclude(kind='*_dep')
+        dataset_ps = b.filter(context='dataset', dataset=dataset)
         dataset_compute_ps = b.filter(context='compute', dataset=dataset, compute=compute, check_visible=False)
-        dataset_kind = dataset_ps.kind
+        dataset_kind = dataset_ps.exclude(kind='*_dep').kind
         time_qualifier = _timequalifier_by_kind(dataset_kind)
         if dataset_kind in ['lc']:
             dataset_components = [None]

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -406,7 +406,7 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
     starrefs  = hier.get_stars()
     meshablerefs = hier.get_meshables()
 
-    do_horizon = computeparams.get_value('horizon', **kwargs)
+    do_horizon = False #computeparams.get_value('horizon', **kwargs)
 
     times, infos, new_syns = _extract_from_bundle_by_time(b, compute=compute,
                                                           times=times,

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -664,17 +664,21 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                 packet[k]['volume'] = body.volume
 
                 packet[k]['vertices'] = body.mesh.vertices_per_triangle
+                packet[k]['roche_vertices'] = body.mesh.roche_vertices_per_triangle
 
-                # TODO: should x, y, z be computed columns of the vertices???
-                # could easily have a read-only property at the ProtoMesh level
-                # that returns a ComputedColumn for xs, ys, zs (like rs)
-                # (also do same for protomesh)
                 if 'xs' in info['columns']:
                     packet[k]['xs'] = body.mesh.centers[:,0]# * u.solRad
                 if 'ys' in info['columns']:
                     packet[k]['ys'] = body.mesh.centers[:,1]# * u.solRad
                 if 'zs' in info['columns']:
                     packet[k]['zs'] = body.mesh.centers[:,2]# * u.solRad
+
+                if 'roche_xs' in info['columns']:
+                    packet[k]['roche_xs'] = body.mesh.roche_centers[:,0]
+                if 'roche_ys' in info['columns']:
+                    packet[k]['roche_ys'] = body.mesh.roche_centers[:,1]
+                if 'roche_zs' in info['columns']:
+                    packet[k]['roche_zs'] = body.mesh.roche_centers[:,2]
 
                 if 'vxs' in info['columns']:
                     packet[k]['vxs'] = body.mesh.velocities.centers[:,0] * u.solRad/u.d # TODO: check units!!!
@@ -686,6 +690,7 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                 if 'areas' in info['columns']:
                     packet[k]['areas'] = body.mesh.areas # * u.solRad**2
                 # if 'tareas' in info['columns']:
+                    # packet[k]['cosbetas'] = body.mesh.cosbetas
 
                 if 'normals' in info['columns']:
                     packet[k]['normals'] = body.mesh.tnormals

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -413,8 +413,8 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
     # TODO: move as much of this pblum logic into mesh.py as possible
 
     enabled_ps = b.filter(qualifier='enabled', compute=compute, value=True)
-    kinds = enabled_ps.kinds
     datasets = enabled_ps.datasets
+    kinds = [b.get_dataset(dataset=ds).exclude(kind='*_dep').kind for ds in datasets]
 
     if 'lc' in kinds or 'rv' in kinds:  # TODO this needs to be WAY more general
 
@@ -430,17 +430,11 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
         system.update_positions(t0, x0, y0, z0, vx0, vy0, vz0, etheta0, elongan0, eincl0, ignore_effects=True)
 
         for dataset in datasets:
-            ds = b.get_dataset(dataset=dataset).exclude(kind='*_dep')
-            kind = ds.kind
-
+            ds = b.get_dataset(dataset=dataset)
+            kind = ds.exclude(kind='*_dep').kind
             if kind not in ['lc']:
                 # only LCs need pblum scaling
                 continue
-
-            # TODO: remove this for-loop... it really doesn't do anything
-            # for component in ds.components:
-                # if component=='_default':
-                    # continue
 
             system.populate_observables(t0, [kind], [dataset],
                                         ignore_effects=True)
@@ -448,7 +442,6 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
             # now for each component we need to store the scaling factor between
             # absolute and relative intensities
             pblum_copy = {}
-            # for component in meshablerefs:
             for component in ds.filter(qualifier='pblum_ref').components:
                 if component=='_default':
                     continue

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -544,8 +544,14 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                 this_syn = new_syns.filter(component=info['component'], dataset=info['dataset'], kind=kind)
 
             for qualifier, value in packet_i.items():
-                # print "*** master_populate_syns qualifier:", qualifier
-                if kind in ['mesh', 'sp']:
+                if qualifier == 'PBCOLUMN':
+                    # now we expect value to be a LIST of DICTS
+                    for pbcol_dict in value:
+                        # each dictionary tells the information to set the valueself.
+                        # Note that the dataset will likely be different than info['dataset']
+                        # so we need to do a new filter
+                        new_syns.set_value(**pbcol_dict)
+                elif kind in ['mesh', 'sp']:
                     # then we're setting the whole array for this given time
                     this_syn.get_parameter(qualifier).set_value(value)
                 else:
@@ -782,22 +788,22 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                 #         packet[k]['horizon_analytic_zs'] = ha['zs']
 
                 # Dataset-dependent quantities
-                # packet[k]['pbmesh'] = []
-                # for infomesh in infolist:
-                #     if infomesh['needs_mesh'] and infomesh['kind'] != 'mesh':
-                #         if 'pblum' in info['columns']:
-                #             packet[k]['pbmesh'] += [{'qualifier': 'pblum', 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.compute_luminosity(infomesh['dataset'])}]
-                #
-                #         if 'ptfarea' in info['columns']:
-                #             packet[k]['pbmesh'] += [{'qualifier': 'ptfarea', 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.get_ptfarea(infomesh['dataset'])}]
-                #
-                #         for indep in ['rvs', 'intensities', 'normal_intensities',
-                #                       'abs_intensities', 'abs_normal_intensities',
-                #                       'boost_factors', 'ldint']:
-                #
-                #             if indep in info['columns']:
-                #                 key = "{}:{}".format(indep, infomesh['dataset'])
-                #                 packet[k]['pbmesh'] += [{'qualifier': indep, 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.mesh[key].centers}]
+                packet[k]['PBCOLUMN'] = []
+                for infomesh in infolist:
+                    if infomesh['needs_mesh'] and infomesh['kind'] != 'mesh':
+                        if 'pblum' in info['columns']:
+                            packet[k]['PBCOLUMN'] += [{'qualifier': 'pblum', 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.compute_luminosity(infomesh['dataset'])}]
+
+                        if 'ptfarea' in info['columns']:
+                            packet[k]['PBCOLUMN'] += [{'qualifier': 'ptfarea', 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.get_ptfarea(infomesh['dataset'])}]
+
+                        for indep in ['rvs', 'intensities', 'normal_intensities',
+                                      'abs_intensities', 'abs_normal_intensities',
+                                      'boost_factors', 'ldint']:
+
+                            if indep in info['columns']:
+                                key = "{}:{}".format(indep, infomesh['dataset'])
+                                packet[k]['PBCOLUMN'] += [{'qualifier': indep, 'dataset': infomesh['dataset'], 'component': info['component'], 'time': time, 'kind': 'mesh', 'value': body.mesh[key].centers}]
 
             else:
                 raise NotImplementedError("kind {} not yet supported by this backend".format(kind))

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -1062,20 +1062,19 @@ def legacy(b, compute, times=[], **kwargs): #, **kwargs):#(b, compute, **kwargs)
 
         # direction is either 'x', 'y', 'z' or None and gives the component
         # of the current array.
-        # Plan for quadrants: no flip, flip x, flip y, flip x&y
-        #                     flip z, flip z&x, flip z&y, flip z&x&y
+        # Plan for quadrants: no flip, flip y, flip z, flip y&z (must be same
+        # order as in potentials.discretize_wd_style so we can compare meshes)
         if direction=='x':
-            a = [+1,-1,+1,-1,+1,-1,+1,-1]
+            a = [+1,+1,+1,+1]
         elif direction=='y':
-            a = [+1,+1,-1,-1,+1,+1,-1,-1]
+            a = [+1,-1,+1,-1]
         elif direction=='z':
-            a = [+1,+1,+1,+1,-1,-1,-1,-1]
+            a = [+1,+1,-1,-1]
         else:
-            # non-vector-component (like teffs)
-            a = [1,1,1,1,1,1,1,1]
+            # non-vector-component (like teffs/loggs)
+            a = [1,1,1,1]
 
-        return np.concatenate([a[0]*value, a[1]*value, a[2]*value, a[3]*value,
-                               a[4]*value, a[5]*value, a[6]*value, a[7]*value])
+        return np.concatenate([a[0]*value, a[1]*value, a[2]*value, a[3]*value])
 
 
     # check whether phoebe legacy is installed

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -107,7 +107,7 @@ def _expand_mesh_times(b, dataset_ps, component):
     # we're first going to access the times@mesh... this should not have a component tag
     this_times = dataset_ps.get_value(qualifier='times', component=None, unit=u.d)
     this_times = np.unique(np.append(this_times,
-                                     [get_times(b, include_times_entry) for include_times_entry in dataset_ps.get_value(qualifier='include_times')]
+                                     [get_times(b, include_times_entry) for include_times_entry in dataset_ps.get_value(qualifier='include_times', expand=True)]
                                      )
                            )
 

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -693,27 +693,27 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
 
                 # times array was set when creating the synthetic ParameterSet
 
-                packetlist.append(make_packet('xs',
+                packetlist.append(make_packet('us',
                                               xi[cind],
                                               time, info))
 
-                packetlist.append(make_packet('ys',
+                packetlist.append(make_packet('vs',
                                               yi[cind],
                                               time, info))
 
-                packetlist.append(make_packet('zs',
+                packetlist.append(make_packet('ws',
                                               zi[cind],
                                               time, info))
 
-                packetlist.append(make_packet('vxs',
+                packetlist.append(make_packet('vus',
                                               vxi[cind],
                                               time, info))
 
-                packetlist.append(make_packet('vys',
+                packetlist.append(make_packet('vvs',
                                               vyi[cind],
                                               time, info))
 
-                packetlist.append(make_packet('vzs',
+                packetlist.append(make_packet('vws',
                                               vzi[cind],
                                               time, info))
 
@@ -722,10 +722,10 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                 # print "*** this_syn.twigs", this_syn.twigs
                 body = system.get_body(info['component'])
 
-                packetlist.append(make_packet('vertices',
+                packetlist.append(make_packet('uvw_elements',
                                               body.mesh.vertices_per_triangle,
                                               time, info))
-                packetlist.append(make_packet('roche_vertices',
+                packetlist.append(make_packet('xyz_elements',
                                               body.mesh.roche_vertices_per_triangle,
                                               time, info))
 
@@ -742,47 +742,98 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                                                   body.volume,
                                                   time, info))
 
-                if 'xs' in info['mesh_columns']:
+                if 'us' in info['mesh_columns']:
                     # UNIT: u.solRad
-                    packetlist.append(make_packet('xs',
+                    packetlist.append(make_packet('us',
                                                   body.mesh.centers[:,0],
                                                   time, info))
-                if 'ys' in info['mesh_columns']:
+                if 'vs' in info['mesh_columns']:
                     # UNIT: u.solRad
-                    packetlist.append(make_packet('ys',
+                    packetlist.append(make_packet('vs',
                                                   body.mesh.centers[:,1],
                                                   time, info))
-                if 'zs' in info['mesh_columns']:
+                if 'ws' in info['mesh_columns']:
                     # UNIT: u.solRad
-                    packetlist.append(make_packet('zs',
+                    packetlist.append(make_packet('ws',
                                                   body.mesh.centers[:,2],
                                                   time, info))
 
-                if 'roche_xs' in info['mesh_columns']:
-                    packetlist.append(make_packet('roche_xs',
+                if 'vus' in info['mesh_columns']:
+                    packetlist.append(make_packet('vus',
+                                                  body.mesh.velocities.centers[:,0] * u.solRad/u.d,
+                                                  time, info))
+                if 'vvs' in info['mesh_columns']:
+                    packetlist.append(make_packet('vvs',
+                                                  body.mesh.velocities.centers[:,1] * u.solRad/u.d,
+                                                  time, info))
+                if 'vws' in info['mesh_columns']:
+                    packetlist.append(make_packet('vws',
+                                                  body.mesh.velocities.centers[:,2] * u.solRad/u.d,
+                                                  time, info))
+
+                # if 'uvw_normals' in info['mesh_columns']:
+                #     packetlist.append(make_packet('uvw_normals',
+                #                                   body.mesh.tnormals,
+                #                                   time, info))
+
+                if 'nus' in info['mesh_columns']:
+                    packetlist.append(make_packet('nus',
+                                                  body.mesh.tnormals[:,0],
+                                                  time, info))
+                if 'nvs' in info['mesh_columns']:
+                    packetlist.append(make_packet('nvs',
+                                                  body.mesh.tnormals[:,1],
+                                                  time, info))
+                if 'nws' in info['mesh_columns']:
+                    packetlist.append(make_packet('nws',
+                                                  body.mesh.tnormals[:,2],
+                                                  time, info))
+
+
+                if 'xs' in info['mesh_columns']:
+                    packetlist.append(make_packet('xs',
                                                   body.mesh.roche_centers[:,0],
                                                   time, info))
-                if 'roche_ys' in info['mesh_columns']:
-                    packetlist.append(make_packet('roche_ys',
+                if 'ys' in info['mesh_columns']:
+                    packetlist.append(make_packet('ys',
                                                   body.mesh.roche_centers[:,1],
                                                   time, info))
-                if 'roche_zs' in info['mesh_columns']:
-                    packetlist.append(make_packet('roche_zs',
+                if 'zs' in info['mesh_columns']:
+                    packetlist.append(make_packet('zs',
                                                   body.mesh.roche_centers[:,2],
                                                   time, info))
 
                 if 'vxs' in info['mesh_columns']:
                     packetlist.append(make_packet('vxs',
-                                                  body.mesh.velocities.centers[:,0] * u.solRad/u.d,
+                                                  body.mesh.roche_cvelocities[:,0] * u.solRad/u.d,
                                                   time, info))
                 if 'vys' in info['mesh_columns']:
                     packetlist.append(make_packet('vys',
-                                                  body.mesh.velocities.centers[:,1] * u.solRad/u.d,
+                                                  body.mesh.roche_cvelocities[:,1] * u.solRad/u.d,
                                                   time, info))
                 if 'vzs' in info['mesh_columns']:
                     packetlist.append(make_packet('vzs',
-                                                  body.mesh.velocities.centers[:,2] * u.solRad/u.d,
+                                                  body.mesh.roche_cvelocities[:,2] * u.solRad/u.d,
                                                   time, info))
+
+                # if 'xyz_normals' in info['mesh_columns']:
+                #     packetlist.append(make_packet('xyz_normals',
+                #                                   body.mesh.tnormals,
+                #                                   time, info))
+
+                if 'nxs' in info['mesh_columns']:
+                    packetlist.append(make_packet('nxs',
+                                                  body.mesh.roche_tnormals[:,0],
+                                                  time, info))
+                if 'nys' in info['mesh_columns']:
+                    packetlist.append(make_packet('nys',
+                                                  body.mesh.roche_tnormals[:,1],
+                                                  time, info))
+                if 'nzs' in info['mesh_columns']:
+                    packetlist.append(make_packet('nzs',
+                                                  body.mesh.roche_tnormals[:,2],
+                                                  time, info))
+
 
                 if 'areas' in info['mesh_columns']:
                     # UNIT: u.solRad**2
@@ -794,22 +845,8 @@ def phoebe(b, compute, times=[], as_generator=False, **kwargs):
                                                   # body.mesh.tareas,
                                                   # time, info))
 
-                if 'normals' in info['mesh_columns']:
-                    packetlist.append(make_packet('normals',
-                                                  body.mesh.tnormals,
-                                                  time, info))
-                if 'nxs' in info['mesh_columns']:
-                    packetlist.append(make_packet('nxs',
-                                                  body.mesh.tnormals[:,0],
-                                                  time, info))
-                if 'nys' in info['mesh_columns']:
-                    packetlist.append(make_packet('nys',
-                                                  body.mesh.tnormals[:,1],
-                                                  time, info))
-                if 'nzs' in info['mesh_columns']:
-                    packetlist.append(make_packet('nzs',
-                                                  body.mesh.tnormals[:,2],
-                                                  time, info))
+
+
 
                 if 'rs' in info['mesh_columns']:
                     packetlist.append(make_packet('rs',

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -149,9 +149,6 @@ def _extract_from_bundle_by_time(b, compute, times=None, allow_oversample=False,
     # but packetlist may be longer than infolist (since mesh passband-columns allow
     # now have their own entries.)
 
-    # we will need access to all datasets@mesh which are enabled
-    mesh_datasets_parameters = [b.get_parameter(qualifier='datasets', context='dataset', dataset=ds) for ds in b.filter(kind='mesh', context='dataset').datasets if b.get_value(qualifier='enabled', compute=compute, dataset=ds)]
-
     for dataset in b.filter(qualifier='enabled', compute=compute, value=True).datasets:
         dataset_ps = b.filter(context='dataset', dataset=dataset).exclude(kind='*_dep')
         dataset_compute_ps = b.filter(context='compute', dataset=dataset, compute=compute, check_visible=False)

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -1144,7 +1144,7 @@ def legacy(b, compute, times=[], **kwargs): #, **kwargs):#(b, compute, **kwargs)
                                                 component=info['component'],
                                                 dataset=info['dataset'])
 
-            phb1.setpar(proximity_par, rv_method=='numerical')
+            phb1.setpar(proximity_par, rv_method=='flux-weighted')
 
             rvs = np.array(rv_call(tuple(info['times'].tolist()), rvind))
             this_syn.set_value('rvs', rvs*u.km/u.s)

--- a/phoebe/backend/mesh.py
+++ b/phoebe/backend/mesh.py
@@ -927,8 +927,10 @@ class ScaledProtoMesh(ProtoMesh):
         # store needed copies in the Roche coordinates
         self._roche_vertices    = None  # Vx3
         self._roche_centers     = None  # Nx3
+        self._roche_cvelocities = None  # Vx3
+        self._roche_tnormals    = None  # Nx3
 
-        keys = ['roche_vertices', 'roche_centers']
+        keys = ['roche_vertices', 'roche_centers', 'roche_cvelocities', 'roche_tnormals']
         keys += kwargs.pop('keys', [])
 
         scale = kwargs.pop('scale', None)
@@ -959,6 +961,8 @@ class ScaledProtoMesh(ProtoMesh):
         # make necessary copies
         self._roche_vertices = self._vertices.copy()
         self._roche_centers = self._centers.copy()
+        self._roche_cvelocities = self._velocities.centers.copy()
+        self._roche_tnormals = self._tnormals.copy()
 
     def _scale_mesh(self, scale):
         """
@@ -1004,6 +1008,25 @@ class ScaledProtoMesh(ProtoMesh):
         :return: numpy array
         """
         return self._roche_centers
+
+    @property
+    def roche_cvelocities(self):
+        """
+        Access to the velocities (compute at the centers of each triangle)
+        in Roche coordinates
+
+        :return: numpy array
+        """
+        return self._roche_cvelocities
+
+    @property
+    def roche_tnormals(self):
+        """
+        Access to the tnormals in Roche coordinates
+
+        :return: numpy array
+        """
+        return self._roche_tnormals
 
 class Mesh(ScaledProtoMesh):
     """

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -814,6 +814,7 @@ class Bundle(ParameterSet):
         for param in self.filter(qualifier='include_times',
                                  context='dataset').to_list():
 
+            # TODO: include t0s per-orbit (will need to update whenever hierarchy changes)
             param._choices = time_datasets
             param.remove_not_in_choices()
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -793,6 +793,31 @@ class Bundle(ParameterSet):
                 else:
                     param.set_value(starrefs[0])
 
+    def _handle_dataset_selectparams(self):
+        """
+        """
+
+        changed_param = self.run_delayed_constraints()
+
+        pbdep_datasets = self.filter(context='dataset',
+                                     kind=_dataset._pbdep_kinds).datasets
+
+        time_datasets = (self.filter(context='dataset')-
+                         self.filter(context='dataset', kind='mesh')).datasets
+
+        for param in self.filter(qualifier='datasets',
+                                 context='dataset').to_list():
+
+            param._choices = pbdep_datasets
+            param.remove_not_in_choices()
+
+        for param in self.filter(qualifier='include_times',
+                                 context='dataset').to_list():
+
+            param._choices = time_datasets
+            param.remove_not_in_choices()
+
+
     def set_hierarchy(self, *args, **kwargs):
         """
         Set the hierarchy of the system.
@@ -1859,6 +1884,7 @@ class Bundle(ParameterSet):
         # this needs to happen before kwargs get applied so that the default
         # values can be overridden by the supplied kwargs
         self._handle_pblum_defaults()
+        self._handle_dataset_selectparams()
 
         for k, v in kwargs.items():
             if isinstance(v, dict):
@@ -1989,6 +2015,8 @@ class Bundle(ParameterSet):
         # not really sure why we need to call this twice, but it seems to do
         # the trick
         self.remove_parameters_all(**kwargs)
+
+        self._handle_dataset_selectparams()
 
         # TODO: check to make sure that trying to undo this
         # will raise an error saying this is not undo-able

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -2512,6 +2512,13 @@ class Bundle(ParameterSet):
             self.as_client(False)
             return self.get_model(model)
 
+        # protomesh and pbmesh were supported kwargs in 2.0.x but are no longer
+        # so let's raise an error if they're passed here
+        if 'protomesh' in kwargs.keys():
+            raise ValueError("protomesh is no longer a valid option")
+        if 'pbmesh' in kwargs.keys():
+            raise ValueError("pbmesh is no longer a valid option")
+
         if model is None:
             model = 'latest'
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -808,7 +808,7 @@ class Bundle(ParameterSet):
         pbdep_datasets = self.filter(context='dataset',
                                      kind=_dataset._pbdep_columns.keys()).datasets
 
-        pbdep_columns = _dataset._mesh_columns
+        pbdep_columns = _dataset._mesh_columns[:] # force deepcopy
         for pbdep_dataset in pbdep_datasets:
             pbdep_kind = self.filter(context='dataset',
                                      dataset=pbdep_dataset,

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -56,7 +56,7 @@ def phoebe(**kwargs):
     # copy_for = {'kind': ['star', 'disk', 'custombody'], 'component': '*'}
     # means that this should exist for each component (since that has a wildcard) which
     # has a kind in [star, disk, custombody]
-    params += [BoolParameter(qualifier='horizon', value=kwargs.get('horizon', False), description='Store horizon for all meshes (except protomeshes)')]
+    # params += [BoolParameter(qualifier='horizon', value=kwargs.get('horizon', False), description='Store horizon for all meshes (except protomeshes)')]
     params += [ChoiceParameter(copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='mesh_method', value=kwargs.get('mesh_method', 'marching'), choices=['marching', 'wd'] if conf.devel else ['marching'], descriptio='Which method to use for discretizing the surface')]
     params += [IntParameter(visible_if='mesh_method:marching', copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='ntriangles', value=kwargs.get('ntriangles', 1500), limits=(100,None), default_unit=u.dimensionless_unscaled, description='Requested number of triangles (won\'t be exact).')]
     params += [ChoiceParameter(visible_if='mesh_method:marching', copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='distortion_method', value=kwargs.get('distortion_method', 'roche'), choices=['roche', 'rotstar', 'nbody', 'sphere'] if conf.devel else ['roche', 'rotstar'], description='Method to use for distorting stars')]

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -56,8 +56,6 @@ def phoebe(**kwargs):
     # copy_for = {'kind': ['star', 'disk', 'custombody'], 'component': '*'}
     # means that this should exist for each component (since that has a wildcard) which
     # has a kind in [star, disk, custombody]
-    params += [BoolParameter(qualifier='protomesh', value=kwargs.get('protomesh', False), description='Store a protomesh (reference frame of stars) at t0 (periastron)')]
-    params += [BoolParameter(qualifier='pbmesh', value=kwargs.get('pbmesh', False), description='Store all meshes created for other datasets (warning: can get memory intensive)')]
     params += [BoolParameter(qualifier='horizon', value=kwargs.get('horizon', False), description='Store horizon for all meshes (except protomeshes)')]
     params += [ChoiceParameter(copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='mesh_method', value=kwargs.get('mesh_method', 'marching'), choices=['marching', 'wd'] if conf.devel else ['marching'], descriptio='Which method to use for discretizing the surface')]
     params += [IntParameter(visible_if='mesh_method:marching', copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='ntriangles', value=kwargs.get('ntriangles', 1500), limits=(100,None), default_unit=u.dimensionless_unscaled, description='Requested number of triangles (won\'t be exact).')]

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -57,7 +57,7 @@ def phoebe(**kwargs):
     # means that this should exist for each component (since that has a wildcard) which
     # has a kind in [star, disk, custombody]
     # params += [BoolParameter(qualifier='horizon', value=kwargs.get('horizon', False), description='Store horizon for all meshes (except protomeshes)')]
-    params += [ChoiceParameter(copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='mesh_method', value=kwargs.get('mesh_method', 'marching'), choices=['marching', 'wd'] if conf.devel else ['marching'], descriptio='Which method to use for discretizing the surface')]
+    params += [ChoiceParameter(copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='mesh_method', value=kwargs.get('mesh_method', 'marching'), choices=['marching', 'wd'] if conf.devel else ['marching'], description='Which method to use for discretizing the surface')]
     params += [IntParameter(visible_if='mesh_method:marching', copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='ntriangles', value=kwargs.get('ntriangles', 1500), limits=(100,None), default_unit=u.dimensionless_unscaled, description='Requested number of triangles (won\'t be exact).')]
     params += [ChoiceParameter(visible_if='mesh_method:marching', copy_for={'kind': ['star', 'envelope'], 'component': '*'}, component='_default', qualifier='distortion_method', value=kwargs.get('distortion_method', 'roche'), choices=['roche', 'rotstar', 'nbody', 'sphere'] if conf.devel else ['roche', 'rotstar'], description='Method to use for distorting stars')]
 

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -127,12 +127,10 @@ def legacy(**kwargs):
     """
     params = []
 
-    params += [BoolParameter(qualifier='enabled', copy_for={'context': 'dataset', 'kind': ['lc', 'rv'], 'dataset': '*'}, visible_if='False', dataset='_default', value=kwargs.get('enabled', True), description='Whether to create synthetics in compute/fitting run')]
+    params += [BoolParameter(qualifier='enabled', copy_for={'context': 'dataset', 'kind': ['lc', 'rv', 'mesh'], 'dataset': '*'}, visible_if='False', dataset='_default', value=kwargs.get('enabled', True), description='Whether to create synthetics in compute/fitting run')]
 
     # TODO: the kwargs need to match the qualifier names!
     # TODO: include MORE meshing options
-    params += [BoolParameter(qualifier='protomesh', value=kwargs.get('protomesh', False), description='Store a protomesh (reference frame of stars) at t0 (periastron)')]
-    params += [BoolParameter(qualifier='pbmesh', value=kwargs.get('pbmesh', False), description='Store all meshes created for other datasets (warning: can get memory intensive)')]
     params += [ChoiceParameter(copy_for = {'kind': ['star'], 'component': '*'}, component='_default', qualifier='atm', value=kwargs.get('atm', 'extern_atmx'), choices=['extern_atmx', 'extern_planckint'], description='Atmosphere table')]
 #    params += [ChoiceParameter(copy_for = {'kind': ['star'], 'component': '*'}, component='_default', qualifier='atm', value=kwargs.get('atm', 'kurucz'), choices=['kurucz', 'blackbody'], description='Atmosphere table')]
 #    params += [ChoiceParameter(qualifier='morphology', value=kwargs.get('morphology','Detached binary'), choices=['Unconstrained binary system', 'Detached binary', 'Overcontact binary of the W UMa type', 'Overcontact binary not in thermal contact'], description='System type constraint')]

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -14,11 +14,15 @@ _mesh_columns = []
 _mesh_columns += ['pot', 'rpole', 'volume']
 
 _mesh_columns += ['xs', 'ys', 'zs']
-_mesh_columns += ['roche_xs', 'roche_ys', 'roche_zs']
 _mesh_columns += ['vxs', 'vys', 'vzs']
+_mesh_columns += ['nxs', 'nys', 'nzs']
+
+_mesh_columns += ['us', 'vs', 'ws']
+_mesh_columns += ['vus', 'vvs', 'vws']
+_mesh_columns += ['nus', 'nvs', 'nws']
+
 # _mesh_columns += ['horizon_xs', 'horizon_ys', 'horizon_zs', 'horizon_analytic_xs', 'horizon_analytic_ys', 'horizon_analytic_zs']
 _mesh_columns += ['areas'] #, 'tareas']
-_mesh_columns += ['normals', 'nxs', 'nys', 'nzs']
 _mesh_columns += ['loggs', 'teffs']
 
 _mesh_columns += ['rprojs', 'mus', 'visibilities', 'visible_centroids']
@@ -250,12 +254,12 @@ def orb_syn(syn=True, **kwargs):
 
     if syn:
         # syns ignore copy_for anyways
-        syn_params += [FloatArrayParameter(qualifier='xs', value=_empty_array(kwargs, 'xs'), default_unit=u.solRad, description='X position')]
-        syn_params += [FloatArrayParameter(qualifier='ys', value=_empty_array(kwargs, 'ys'), default_unit=u.solRad, description='Y position')]
-        syn_params += [FloatArrayParameter(qualifier='zs', value=_empty_array(kwargs, 'zs'), default_unit=u.solRad, description='Z position')]
-        syn_params += [FloatArrayParameter(qualifier='vxs', value=_empty_array(kwargs, 'vxs'), default_unit=u.solRad/u.d, description='X velocity')]
-        syn_params += [FloatArrayParameter(qualifier='vys', value=_empty_array(kwargs, 'vys'), default_unit=u.solRad/u.d, description='Y velocity')]
-        syn_params += [FloatArrayParameter(qualifier='vzs', value=_empty_array(kwargs, 'vzs'), default_unit=u.solRad/u.d, description='Z velocity')]
+        syn_params += [FloatArrayParameter(qualifier='us', value=_empty_array(kwargs, 'us'), default_unit=u.solRad, description='U position')]
+        syn_params += [FloatArrayParameter(qualifier='vs', value=_empty_array(kwargs, 'vs'), default_unit=u.solRad, description='V position')]
+        syn_params += [FloatArrayParameter(qualifier='ws', value=_empty_array(kwargs, 'ws'), default_unit=u.solRad, description='W position')]
+        syn_params += [FloatArrayParameter(qualifier='vus', value=_empty_array(kwargs, 'vus'), default_unit=u.solRad/u.d, description='U velocity')]
+        syn_params += [FloatArrayParameter(qualifier='vvs', value=_empty_array(kwargs, 'vvs'), default_unit=u.solRad/u.d, description='V velocity')]
+        syn_params += [FloatArrayParameter(qualifier='vws', value=_empty_array(kwargs, 'vws'), default_unit=u.solRad/u.d, description='W velocity')]
 
     constraints = []
 
@@ -312,8 +316,8 @@ def mesh_syn(syn=True, **kwargs):
 
 
             # always include basic geometric columns
-            syn_params += [FloatArrayParameter(qualifier='vertices', time=t, value=kwargs.get('vertices', []), default_unit=u.solRad, description='Vertices of triangles in the plane-of-sky')]
-            syn_params += [FloatArrayParameter(qualifier='roche_vertices', time=t, value=kwargs.get('roche_vertices', []), default_unit=u.dimensionless_unscaled, description='Vertices of triangles in Roche coordinates')]
+            syn_params += [FloatArrayParameter(qualifier='uvw_elements', time=t, value=kwargs.get('uvw_elements', []), default_unit=u.solRad, description='Vertices of triangles in the plane-of-sky')]
+            syn_params += [FloatArrayParameter(qualifier='xyz_elements', time=t, value=kwargs.get('xyz_elements ', []), default_unit=u.dimensionless_unscaled, description='Vertices of triangles in Roche coordinates')]
 
             # NOTE: if changing the parameters which are optional, changes must
             # be made here, in the choices for the columns Parameter, and in
@@ -335,14 +339,6 @@ def mesh_syn(syn=True, **kwargs):
             if 'zs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='zs', time=t, value=kwargs.get('zs', []), default_unit=u.solRad, description='Z coordinate of center of triangles in the plane-of-sky')]
 
-            if 'roche_xs' in columns:
-                syn_params += [FloatArrayParameter(qualifier='roche_xs', time=t, value=kwargs.get('roche_xs', []), default_unit=u.dimensionless_unscaled, description='X coordinate of center of triangles in Roche coordinates')]
-            if 'roche_ys' in columns:
-                syn_params += [FloatArrayParameter(qualifier='roche_ys', time=t, value=kwargs.get('roche_ys', []), default_unit=u.dimensionless_unscaled, description='Y coordinate of center of triangles in Roche coordinates')]
-            if 'roche_zs' in columns:
-                syn_params += [FloatArrayParameter(qualifier='roche_zs', time=t, value=kwargs.get('roche_zs', []), default_unit=u.dimensionless_unscaled, description='Z coordinate of center of triangles in Roche coordinates')]
-
-
             if 'vxs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='vxs', time=t, value=kwargs.get('vxs', []), default_unit=u.solRad/u.d, description='X velocity of center of triangles')]
             if 'vys' in columns:
@@ -350,19 +346,40 @@ def mesh_syn(syn=True, **kwargs):
             if 'vzs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='vzs', time=t, value=kwargs.get('vzs', []), default_unit=u.solRad/u.d, description='Z velocity of center of triangles')]
 
-            if 'areas' in columns:
-                syn_params += [FloatArrayParameter(qualifier='areas', time=t, value=kwargs.get('areas', []), default_unit=u.solRad**2, description='Area of triangles')]
-            # if 'tareas' in columns:
-                # syn_params += [FloatArrayParameter(qualifier='tareas', time=t, value=kwargs.get('areas', []), default_unit=u.solRad**2, description='Area of WD triangles')]
-
-            if 'normals' in columns:
-                syn_params += [FloatArrayParameter(qualifier='normals', time=t, value=kwargs.get('normals', []), default_unit=u.dimensionless_unscaled, description='Normals of triangles')]
             if 'nxs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='nxs', time=t, value=kwargs.get('nxs', []), default_unit=u.dimensionless_unscaled, description='X component of normals')]
             if 'nys' in columns:
                 syn_params += [FloatArrayParameter(qualifier='nys', time=t, value=kwargs.get('nys', []), default_unit=u.dimensionless_unscaled, description='Y component of normals')]
             if 'nzs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='nzs', time=t, value=kwargs.get('nzs', []), default_unit=u.dimensionless_unscaled, description='Z component of normals')]
+
+            if 'us' in columns:
+                syn_params += [FloatArrayParameter(qualifier='us', time=t, value=kwargs.get('us', []), default_unit=u.solRad, description='U coordinate of center of triangles in the plane-of-sky')]
+            if 'vs' in columns:
+                syn_params += [FloatArrayParameter(qualifier='vs', time=t, value=kwargs.get('vs', []), default_unit=u.solRad, description='V coordinate of center of triangles in the plane-of-sky')]
+            if 'ws' in columns:
+                syn_params += [FloatArrayParameter(qualifier='ws', time=t, value=kwargs.get('ws', []), default_unit=u.solRad, description='W coordinate of center of triangles in the plane-of-sky')]
+
+            if 'vus' in columns:
+                syn_params += [FloatArrayParameter(qualifier='vus', time=t, value=kwargs.get('vus', []), default_unit=u.solRad/u.d, description='U velocity of center of triangles')]
+            if 'vvs' in columns:
+                syn_params += [FloatArrayParameter(qualifier='vvs', time=t, value=kwargs.get('vvs', []), default_unit=u.solRad/u.d, description='V velocity of center of triangles')]
+            if 'vws' in columns:
+                syn_params += [FloatArrayParameter(qualifier='vws', time=t, value=kwargs.get('vws', []), default_unit=u.solRad/u.d, description='W velocity of center of triangles')]
+
+            if 'nus' in columns:
+                syn_params += [FloatArrayParameter(qualifier='nus', time=t, value=kwargs.get('nus', []), default_unit=u.dimensionless_unscaled, description='U component of normals')]
+            if 'nvs' in columns:
+                syn_params += [FloatArrayParameter(qualifier='nvs', time=t, value=kwargs.get('nvs', []), default_unit=u.dimensionless_unscaled, description='V component of normals')]
+            if 'nws' in columns:
+                syn_params += [FloatArrayParameter(qualifier='nws', time=t, value=kwargs.get('nws', []), default_unit=u.dimensionless_unscaled, description='W component of normals')]
+
+
+            if 'areas' in columns:
+                syn_params += [FloatArrayParameter(qualifier='areas', time=t, value=kwargs.get('areas', []), default_unit=u.solRad**2, description='Area of triangles')]
+            # if 'tareas' in columns:
+                # syn_params += [FloatArrayParameter(qualifier='tareas', time=t, value=kwargs.get('areas', []), default_unit=u.solRad**2, description='Area of WD triangles')]
+
 
             if 'rs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='rs', time=t, value=kwargs.get('rs', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='Distance of each triangle from center of mass')]

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -7,6 +7,9 @@ from phoebe import conf
 
 _ld_func_choices = ['interp', 'linear', 'logarithmic', 'quadratic', 'square_root', 'power']
 
+global _pbdep_kinds
+_pbdep_kinds = ['lc', 'rv']
+
 def _empty_array(kwargs, qualifier):
     if qualifier in kwargs.keys():
         return kwargs.get(qualifier)
@@ -256,6 +259,24 @@ def mesh(**kwargs):
 
     syn_params, constraints = mesh_syn(syn=False, **kwargs)
     obs_params += syn_params.to_list()
+
+    obs_params += [SelectParameter(qualifier='include_times', value=kwargs.get('include_times', []), description='append to times from the following datasets/time standards', choices=[])]
+
+    obs_params += [SelectParameter(qualifier='datasets', value=kwargs.get('datasets', []), description='datasets to expose as mesh columns', choices=[])]
+    columns_choices = ['vxs', 'vys', 'vzs']
+    # columns_choices += ['horizon_xs', 'horizon_ys', 'horizon_zs', 'horizon_analytic_xs', 'horizon_analytic_ys', 'horizon_analytic_zs']
+    columns_choices += ['areas', 'tareas']
+    columns_choices += ['normals', 'nxs', 'nys', 'nzs']
+    columns_choices += ['loggs', 'teffs']
+
+    columns_choices += ['rprojs', 'mus', 'visible_centroids', 'visibilities']
+    columns_choices += ['rs', 'cosbetas']
+
+    columns_choices += ['intensities', 'normal_intensities', 'abs_intensities', 'abs_normal_intensities']
+    columns_choices += ['boost_factors', 'ldint']
+    columns_choices += ['rvs']
+
+    obs_params += [SelectParameter(qualifier='columns', value=kwargs.get('columns', ['loggs', 'teffs', 'intensities', 'rvs']), description='columns to expose within the mesh', choices=columns_choices)]
     #obs_params += mesh_dep(**kwargs).to_list()
 
     return ParameterSet(obs_params), constraints

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -299,8 +299,9 @@ def mesh_syn(syn=True, **kwargs):
 
     # the following will all be arrays (value per triangle) per time
     if syn:
-        columns = kwargs.get('columns', [])
-        datasets = kwargs.get('datasets', [])
+        columns = kwargs.get('mesh_columns', [])
+        datasets = kwargs.get('mesh_datasets', [])
+        dataset_kinds = kwargs.get('mesh_kinds', [])
 
         for t in times:
             if not isinstance(t, float):
@@ -387,7 +388,7 @@ def mesh_syn(syn=True, **kwargs):
             # syn_params += [FloatArrayParameter(qualifier='horizon_analytic_ys', time=t, value=kwargs.get('horizon_analytic_ys', []), default_unit=u.solRad, description='Analytic horizon (interpolated, y component)')]
             # syn_params += [FloatArrayParameter(qualifier='horizon_analytic_zs', time=t, value=kwargs.get('horizon_analytic_zs', []), default_unit=u.solRad, description='Analytic horizon (interpolated, z component)')]
 
-            for dataset, kind in datasets.items():
+            for dataset, kind in zip(datasets, dataset_kinds):
                 if 'rvs' in columns and kind=='rv':
                     syn_params += [FloatArrayParameter(qualifier='rvs', dataset=dataset, time=t, value=[], default_unit=u.solRad/u.d, description='Per-element value of rvs for {} dataset'.format(dataset))]
                 if 'intensities' in columns:

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -288,7 +288,7 @@ def mesh(**kwargs):
 
     obs_params += [SelectParameter(qualifier='include_times', value=kwargs.get('include_times', ['t0@system']), description='append to times from the following datasets/time standards', choices=['t0@system'])]
 
-    obs_params += [SelectParameter(qualifier='columns', value=kwargs.get('columns', ['teffs']), description='columns to expose within the mesh', choices=_mesh_columns)]
+    obs_params += [SelectParameter(qualifier='columns', value=kwargs.get('columns', []), description='columns to expose within the mesh', choices=_mesh_columns)]
     #obs_params += mesh_dep(**kwargs).to_list()
 
     return ParameterSet(obs_params), constraints

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -260,7 +260,7 @@ def mesh(**kwargs):
     syn_params, constraints = mesh_syn(syn=False, **kwargs)
     obs_params += syn_params.to_list()
 
-    obs_params += [SelectParameter(qualifier='include_times', value=kwargs.get('include_times', []), description='append to times from the following datasets/time standards', choices=[])]
+    obs_params += [SelectParameter(qualifier='include_times', value=kwargs.get('include_times', ['t0@system']), description='append to times from the following datasets/time standards', choices=['t0@system'])]
 
     obs_params += [SelectParameter(qualifier='datasets', value=kwargs.get('datasets', []), description='datasets to expose as mesh columns', choices=[])]
     columns_choices = []

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -382,9 +382,9 @@ def mesh_syn(syn=True, **kwargs):
 
 
             if 'rs' in columns:
-                syn_params += [FloatArrayParameter(qualifier='rs', time=t, value=kwargs.get('rs', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='Distance of each triangle from center of mass')]
+                syn_params += [FloatArrayParameter(qualifier='rs', time=t, value=kwargs.get('rs', []), default_unit=u.solRad, description='Distance of each triangle from center of mass')]
             # if 'cosbetas' in columns:
-            #     syn_params += [FloatArrayParameter(qualifier='cosbetas', time=t, value=kwargs.get('cosbetas', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='')]
+            #     syn_params += [FloatArrayParameter(qualifier='cosbetas', time=t, value=kwargs.get('cosbetas', []), default_unit=u.solRad, description='')]
 
 
             if 'loggs' in columns:

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -288,8 +288,6 @@ def mesh(**kwargs):
 
     obs_params += [SelectParameter(qualifier='include_times', value=kwargs.get('include_times', ['t0@system']), description='append to times from the following datasets/time standards', choices=['t0@system'])]
 
-    obs_params += [SelectParameter(qualifier='datasets', value=kwargs.get('datasets', []), description='datasets to expose as mesh columns', choices=[])]
-
     obs_params += [SelectParameter(qualifier='columns', value=kwargs.get('columns', ['teffs']), description='columns to expose within the mesh', choices=_mesh_columns)]
     #obs_params += mesh_dep(**kwargs).to_list()
 

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -264,6 +264,7 @@ def mesh(**kwargs):
 
     obs_params += [SelectParameter(qualifier='datasets', value=kwargs.get('datasets', []), description='datasets to expose as mesh columns', choices=[])]
     columns_choices = ['xs', 'ys', 'zs']
+    columns_choices += ['roche_xs', 'roche_ys', 'roche_zs']
     columns_choices += ['vxs', 'vys', 'vzs']
     # columns_choices += ['horizon_xs', 'horizon_ys', 'horizon_zs', 'horizon_analytic_xs', 'horizon_analytic_ys', 'horizon_analytic_zs']
     columns_choices += ['areas'] #, 'tareas']
@@ -304,7 +305,8 @@ def mesh_syn(syn=True, **kwargs):
             syn_params += [FloatParameter(qualifier='volume', time=t, value=kwargs.get('volume', 0.0), default_unit=u.solRad**3, description='Volume of the stellar surface')]
 
             # always include basic geometric columns
-            syn_params += [FloatArrayParameter(qualifier='vertices', time=t, value=kwargs.get('vertices', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='Vertices of triangles')]
+            syn_params += [FloatArrayParameter(qualifier='vertices', time=t, value=kwargs.get('vertices', []), default_unit=u.solRad, description='Vertices of triangles in the plane-of-sky')]
+            syn_params += [FloatArrayParameter(qualifier='roche_vertices', time=t, value=kwargs.get('roche_vertices', []), default_unit=u.dimensionless_unscaled, description='Vertices of triangles in Roche coordinates')]
 
             # NOTE: if changing the parameters which are optional, changes must
             # be made here, in the choices for the columns Parameter, and in
@@ -312,11 +314,20 @@ def mesh_syn(syn=True, **kwargs):
             # packet
 
             if 'xs' in columns:
-                syn_params += [FloatArrayParameter(qualifier='xs', time=t, value=kwargs.get('xs', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='X coordinate of center of triangles')]
+                syn_params += [FloatArrayParameter(qualifier='xs', time=t, value=kwargs.get('xs', []), default_unit=u.solRad, description='X coordinate of center of triangles in the plane-of-sky')]
             if 'ys' in columns:
-                syn_params += [FloatArrayParameter(qualifier='ys', time=t, value=kwargs.get('ys', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='Y coordinate of center of triangles')]
+                syn_params += [FloatArrayParameter(qualifier='ys', time=t, value=kwargs.get('ys', []), default_unit=u.solRad, description='Y coordinate of center of triangles in the plane-of-sky')]
             if 'zs' in columns:
-                syn_params += [FloatArrayParameter(qualifier='zs', time=t, value=kwargs.get('zs', []), default_unit=u.solRad if t is not None else u.dimensionless_unscaled, description='Z coordinate of center of triangles')]
+                syn_params += [FloatArrayParameter(qualifier='zs', time=t, value=kwargs.get('zs', []), default_unit=u.solRad, description='Z coordinate of center of triangles in the plane-of-sky')]
+
+            if 'roche_xs' in columns:
+                syn_params += [FloatArrayParameter(qualifier='roche_xs', time=t, value=kwargs.get('roche_xs', []), default_unit=u.dimensionless_unscaled, description='X coordinate of center of triangles in Roche coordinates')]
+            if 'roche_ys' in columns:
+                syn_params += [FloatArrayParameter(qualifier='roche_ys', time=t, value=kwargs.get('roche_ys', []), default_unit=u.dimensionless_unscaled, description='Y coordinate of center of triangles in Roche coordinates')]
+            if 'roche_zs' in columns:
+                syn_params += [FloatArrayParameter(qualifier='roche_zs', time=t, value=kwargs.get('roche_zs', []), default_unit=u.dimensionless_unscaled, description='Z coordinate of center of triangles in Roche coordinates')]
+
+
 
             if 'vxs' in columns:
                 syn_params += [FloatArrayParameter(qualifier='vxs', time=t, value=kwargs.get('vxs', []), default_unit=u.solRad/u.d, description='X velocity of center of triangles')]

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -283,7 +283,8 @@ def mesh(**kwargs):
     columns_choices += ['rvs']
     columns_choices += ['pblum', 'ptfarea']
 
-    obs_params += [SelectParameter(qualifier='columns', value=kwargs.get('columns', ['loggs', 'teffs', 'intensities', 'rvs']), description='columns to expose within the mesh', choices=columns_choices)]
+    # TODO: split this into columns and dataset_columns???
+    obs_params += [SelectParameter(qualifier='columns', value=kwargs.get('columns', ['teffs']), description='columns to expose within the mesh', choices=columns_choices)]
     #obs_params += mesh_dep(**kwargs).to_list()
 
     return ParameterSet(obs_params), constraints
@@ -299,6 +300,7 @@ def mesh_syn(syn=True, **kwargs):
     # the following will all be arrays (value per triangle) per time
     if syn:
         columns = kwargs.get('columns', [])
+        datasets = kwargs.get('datasets', [])
 
         for t in times:
             if not isinstance(t, float):
@@ -385,28 +387,26 @@ def mesh_syn(syn=True, **kwargs):
             # syn_params += [FloatArrayParameter(qualifier='horizon_analytic_ys', time=t, value=kwargs.get('horizon_analytic_ys', []), default_unit=u.solRad, description='Analytic horizon (interpolated, y component)')]
             # syn_params += [FloatArrayParameter(qualifier='horizon_analytic_zs', time=t, value=kwargs.get('horizon_analytic_zs', []), default_unit=u.solRad, description='Analytic horizon (interpolated, z component)')]
 
-            for dataset, kind in kwargs.get('dataset_fields', {}).items():
-                # TODO: descriptions for each column
-                if kind in ['lc', 'rv']:
-                    if 'rvs' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='rvs', dataset=dataset, time=t, value=[], default_unit=u.solRad/u.d, description='Per-element value of rvs for {} dataset'.format(dataset))]
-                    if 'intensities' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of intensities for {} dataset'.format(dataset))]
-                    if 'normal_intensities' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='normal_intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of normal_intensities for {} dataset'.format(dataset))]
-                    if 'abs_intensities' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='abs_intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of abs_intensities for {} dataset'.format(dataset))]
-                    if 'abs_normal_intensities' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='abs_normal_intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of abs_normal_intensities for {} dataset'.format(dataset))]
-                    if 'boost_factors' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='boost_factors', dataset=dataset, time=t, value=[], default_unit=u.dimensionless_unscaled, description='Per-element value of boost_factors for {} dataset'.format(dataset))]
-                    if 'ldint' in columns:
-                        syn_params += [FloatArrayParameter(qualifier='ldint', dataset=dataset, time=t, value=kwargs.get('ldint', []), default_unit=u.dimensionless_unscaled, description='Integral of the limb-darkening function')]
+            for dataset in datasets:
+                if 'rvs' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='rvs', dataset=dataset, time=t, value=[], default_unit=u.solRad/u.d, description='Per-element value of rvs for {} dataset'.format(dataset))]
+                if 'intensities' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of intensities for {} dataset'.format(dataset))]
+                if 'normal_intensities' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='normal_intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of normal_intensities for {} dataset'.format(dataset))]
+                if 'abs_intensities' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='abs_intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of abs_intensities for {} dataset'.format(dataset))]
+                if 'abs_normal_intensities' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='abs_normal_intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of abs_normal_intensities for {} dataset'.format(dataset))]
+                if 'boost_factors' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='boost_factors', dataset=dataset, time=t, value=[], default_unit=u.dimensionless_unscaled, description='Per-element value of boost_factors for {} dataset'.format(dataset))]
+                if 'ldint' in columns:
+                    syn_params += [FloatArrayParameter(qualifier='ldint', dataset=dataset, time=t, value=kwargs.get('ldint', []), default_unit=u.dimensionless_unscaled, description='Integral of the limb-darkening function')]
 
-                    if 'ptfarea' in columns:
-                        syn_params += [FloatParameter(qualifier='ptfarea', dataset=dataset, time=t, value=kwargs.get('ptfarea', 1.0), default_unit=u.m, description='Area of the passband transmission function')]
-                    if 'pblum' in columns:
-                        syn_params += [FloatParameter(qualifier='pblum', dataset=dataset, time=t, value=kwargs.get('pblum', 0.0), default_unit=u.W, description='Passband Luminosity of entire star')]
+                if 'ptfarea' in columns:
+                    syn_params += [FloatParameter(qualifier='ptfarea', dataset=dataset, time=t, value=kwargs.get('ptfarea', 1.0), default_unit=u.m, description='Area of the passband transmission function')]
+                if 'pblum' in columns:
+                    syn_params += [FloatParameter(qualifier='pblum', dataset=dataset, time=t, value=kwargs.get('pblum', 0.0), default_unit=u.W, description='Passband Luminosity of entire star')]
 
     constraints = []
 

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -387,8 +387,8 @@ def mesh_syn(syn=True, **kwargs):
             # syn_params += [FloatArrayParameter(qualifier='horizon_analytic_ys', time=t, value=kwargs.get('horizon_analytic_ys', []), default_unit=u.solRad, description='Analytic horizon (interpolated, y component)')]
             # syn_params += [FloatArrayParameter(qualifier='horizon_analytic_zs', time=t, value=kwargs.get('horizon_analytic_zs', []), default_unit=u.solRad, description='Analytic horizon (interpolated, z component)')]
 
-            for dataset in datasets:
-                if 'rvs' in columns:
+            for dataset, kind in datasets.items():
+                if 'rvs' in columns and kind=='rv':
                     syn_params += [FloatArrayParameter(qualifier='rvs', dataset=dataset, time=t, value=[], default_unit=u.solRad/u.d, description='Per-element value of rvs for {} dataset'.format(dataset))]
                 if 'intensities' in columns:
                     syn_params += [FloatArrayParameter(qualifier='intensities', dataset=dataset, time=t, value=[], default_unit=u.W/u.m**3, description='Per-element value of intensities for {} dataset'.format(dataset))]

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -96,7 +96,7 @@ _meta_fields_twig = ['time', 'qualifier', 'history', 'feature', 'component',
                      'context']
 
 _meta_fields_all = _meta_fields_twig + ['twig', 'uniquetwig', 'uniqueid']
-_meta_fields_filter = _meta_fields_all + ['constraint_func']
+_meta_fields_filter = _meta_fields_all + ['constraint_func', 'value']
 
 _contexts = ['history', 'system', 'component', 'feature',
              'dataset', 'constraint', 'compute', 'model', 'fitting',

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3890,7 +3890,7 @@ class SelectParameter(Parameter):
         _orig_value = deepcopy(self.get_value())
 
         if not isinstance(value, list):
-            raise TypeError("value must be a list of strings")
+            raise TypeError("value must be a list of strings, received {}".format(type, value))
 
         try:
             value = [str(v) for v in value]
@@ -3913,6 +3913,13 @@ class SelectParameter(Parameter):
                 logger.warning(msg)
 
         self._add_history(redo_func='set_value', redo_kwargs={'value': value, 'uniqueid': self.uniqueid}, undo_func='set_value', undo_kwargs={'value': _orig_value, 'uniqueid': self.uniqueid})
+
+    def remove_not_in_choices(self):
+        """
+        update the value to remove any that are (no longer) in choices
+        """
+        value = [v for v in self.get_value() if v in self.get_choices]
+        self.set_value(value)
 
     def __add__(self, other):
         if not isinstance(other, list):

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3914,23 +3914,16 @@ class ChoiceParameter(Parameter):
             logger.info("downloading passband: {}".format(value))
             download_passband(value)
 
-            # run_checks if requested (default)
-            if run_checks is None:
-                run_checks = conf.interactive_checks
-            if run_checks and self._bundle:
-                passed, msg = self._bundle.run_checks()
-                if not passed:
-                    # passed is either False (failed) or None (raise Warning)
-                    msg += "  If not addressed, this warning will continue to be raised and will throw an error at run_compute."
-                    logger.warning(msg)
+        self._value = value
 
         # run_checks if requested (default)
         if run_checks is None:
-            run_checks = conf.interactive
+            run_checks = conf.interactive_checks
         if run_checks and self._bundle:
             passed, msg = self._bundle.run_checks()
             if not passed:
                 # passed is either False (failed) or None (raise Warning)
+                msg += "  If not addressed, this warning will continue to be raised and will throw an error at run_compute."
                 logger.warning(msg)
 
         self._add_history(redo_func='set_value', redo_kwargs={'value': value, 'uniqueid': self.uniqueid}, undo_func='set_value', undo_kwargs={'value': _orig_value, 'uniqueid': self.uniqueid})
@@ -4026,7 +4019,7 @@ class SelectParameter(Parameter):
 
         # run_checks if requested (default)
         if run_checks is None:
-            run_checks = conf.interactive
+            run_checks = conf.interactive_checks
         if run_checks and self._bundle:
             passed, msg = self._bundle.run_checks()
             if not passed:

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3942,7 +3942,7 @@ class SelectParameter(Parameter):
         """
         update the value to remove any that are (no longer) in choices
         """
-        value = [v for v in self.get_value() if v in self.get_choices]
+        value = [v for v in self.get_value() if v in self.get_choices()]
         self.set_value(value)
 
     def __add__(self, other):

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -133,6 +133,8 @@ _singular_to_plural = {'time': 'times', 'flux': 'fluxes', 'sigma': 'sigmas',
                        'time_ephem': 'time_ephems', 'N': 'Ns', 'x': 'xs',
                        'y': 'ys', 'z': 'zs', 'vx': 'vxs', 'vy': 'vys',
                        'vz': 'vzs', 'nx': 'nxs', 'ny': 'nys', 'nz': 'nzs',
+                       'u': 'us', 'v': 'vs', 'w': 'ws', 'vu': 'vus', 'vv': 'vvs',
+                       'vw': 'vws', 'nu': 'nus', 'nv': 'nvs', 'nw': 'nws',
                        'cosbeta': 'cosbetas', 'logg': 'loggs', 'teff': 'teffs',
                        'r': 'rs', 'r_proj': 'r_projs', 'mu': 'mus',
                        'visibility': 'visibilities'}
@@ -1936,10 +1938,6 @@ class ParameterSet(object):
         if len(ps.datasets)>1 and ps.kind not in ['mesh']:
             return_ = []
             for dataset in ps.datasets:
-                if dataset in ['protomesh']:
-                    # let's not automatically plot the protomesh unless its
-                    # requested in which case we'll never enter this loop
-                    continue
                 this_return = ps.filter(dataset=dataset).get_plotting_info(**kwargs)
                 return_ += this_return
             return return_
@@ -1999,19 +1997,45 @@ class ParameterSet(object):
         # and z are all the coordinates (then we'll plot the triangles).
         # Otherwise, we will continue and can use the generic x, y plotting (ie
         # for flux vs r_proj)
+        do_plot_mesh_coordinates = None
         if ps.kind in ['mesh', 'mesh_syn'] and \
+                kwargs.get('x', 'us') in ['us', 'vs', 'ws'] and \
+                kwargs.get('y', 'vs') in ['us', 'vs', 'ws'] and \
+                kwargs.get('z', 'ws') in ['us', 'vs', 'ws']:
+
+            do_plot_mesh_coordinates = 'uvw'
+
+            # NOTE: even though we are calling these u, v, w - we really mean
+            # to get those components from the uvw_elements array
+            xqualifier = kwargs.get('x', 'us')
+            yqualifier = kwargs.get('y', 'vs')
+            if axes_3d:
+                zqualifier = kwargs.get('z', 'ws')
+
+
+            # All our arrays will need to be sorted front to back, so we need
+            # the centers from the coordinates not covered by xqualifier,
+            # yqualifier. We don't really care the units here, but in case the
+            # user has changed the default units on some of the components to
+            # be different than others, we'll request them all in the same
+            # units.
+
+            # TODO: should we skip this for axes_3d?
+            mesh_coordinates = ['us', 'vs', 'ws']
+            sortqualifier = ['us', 'vs', 'ws']
+            sortqualifier.remove(xqualifier)
+            sortqualifier.remove(yqualifier)
+            sortqualifier = sortqualifier[0]
+
+        elif ps.kind in ['mesh', 'mesh_syn'] and \
                 kwargs.get('x', 'xs') in ['xs', 'ys', 'zs'] and \
                 kwargs.get('y', 'ys') in ['xs', 'ys', 'zs'] and \
                 kwargs.get('z', 'zs') in ['xs', 'ys', 'zs']:
 
-            # TODO: here we want to call a different plotting function - note
-            # that meshes don't need to iterate over components like everything
-            # else will Keep in mind that we still want this to be plotting-
-            # backend dependent, so perhaps there will be a plotting.mpl_mesh
-            # function which will handle the output from preparing the arrays
+            do_plot_mesh_coordinates = 'xyz'
 
             # NOTE: even though we are calling these x, y, z - we really mean
-            # to get those components from the triangles array
+            # to get those components from the xyz_elements array
             xqualifier = kwargs.get('x', 'xs')
             yqualifier = kwargs.get('y', 'ys')
             if axes_3d:
@@ -2026,25 +2050,14 @@ class ParameterSet(object):
             # units.
 
             # TODO: should we skip this for axes_3d?
+            mesh_coordinates = ['xs', 'ys', 'zs']
             sortqualifier = ['xs', 'ys', 'zs']
             sortqualifier.remove(xqualifier)
             sortqualifier.remove(yqualifier)
             sortqualifier = sortqualifier[0]
 
-            if kwargs.get('loop_times', False) or len(ps.times) <= 1:
-                center_sort = np.concatenate([ps.get_value(sortqualifier,
-                                                           component=c,
-                                                           unit=u.solRad if ps.dataset!='protomesh' else None)
-                                              for c in ps.components if c != '_default'])
-            else:
-                center_sort = np.concatenate([ps.get_value(sortqualifier,
-                                                           component=c,
-                                                           time=t,
-                                                           unit=u.solRad if ps.dataset!='protomesh' else None)
-                                              for c in ps.components if c != '_default'
-                                              for t in ps.times])
 
-            plot_inds = np.argsort(center_sort)
+        if do_plot_mesh_coordinates is not None:
 
             # if color is provided, it should be used for facecolor and
             # edgecolor, but if either of those two values are provided, they
@@ -2077,14 +2090,14 @@ class ParameterSet(object):
             # TODO: do the same logic with cmap, facecmap, edgecmap as colors
             # above
 
-            if ps.dataset == 'protomesh':
+            if do_plot_mesh_coordinates=='xyz':
                 # then the array are dimensionless - which really means in
                 # units of sma
                 kwargs.setdefault('xunit', None)
                 kwargs.setdefault('yunit', None)
                 if axes_3d:
                     kwargs.setdefault('zunit', None)
-            else:
+            else: # uvw
                 kwargs.setdefault('xunit', 'solRad')
                 kwargs.setdefault('yunit', 'solRad')
                 if axes_3d:
@@ -2121,30 +2134,32 @@ class ParameterSet(object):
             if kwargs.get('edgecolorbar', False) or kwargs.get('colorbar', False):
                 kwargs.setdefault('edgecolorlabel', r"{} ({})".format(_qualifier_to_label(edgecolorqualifier), _unit_to_str(kwargs['edgecolorunit'], use_latex=plotting_backend in ['mpl'])) if kwargs['edgecolorunit'] not in [None, u.dimensionless_unscaled] else _qualifier_to_label(edgecolorqualifier))
 
-            # vertices_xyz are the REAL x, y, z coordinates.  Later we'll convert
-            # to the quantities we want to plot along the x and y axes
-
-            #vertices_xyz = np.concatenate([ps.get_value('vertices', component=c, time=t, unit=kwargs['xunit']) for c in ps.components for t in ps.times]).reshape((-1, 3, 3))[:, :, :]
-
             if kwargs.get('loop_times', False) or len(ps.times) <= 1:
-                vertices_xyz = np.concatenate([ps.get_value('vertices',
+                elements_xyz = np.concatenate([ps.get_value('{}_elements'.format(do_plot_mesh_coordinates),
                                                             component=c,
                                                             unit=kwargs['xunit'])
                                                for c in ps.components]).reshape((-1, 3, 3))[:, :, :]
             else:
-                vertices_xyz = np.concatenate([ps.get_value('vertices',
+                elements_xyz = np.concatenate([ps.get_value('{}_elements'.format(do_plot_mesh_coordinates),
                                                             component=c,
                                                             time=t,
                                                             unit=kwargs['xunit'])
                                                for c in ps.components for t in ps.times]).reshape((-1, 3, 3))[:, :, :]
 
+            center_sort = np.mean(elements_xyz[:, :, mesh_coordinates.index(sortqualifier)], axis=1)
+            plot_inds = np.argsort(center_sort)
+
+            # vertices_xyz are the REAL x, y, z coordinates.  Later we'll convert
+            # to the quantities we want to plot along the x and y axes
+            vertices_xyz = elements_xyz.reshape((-1, 3, 3))[:, :, :]
+
             # TODO: make this handle 3d by just iterating over zqualifier as
             # well (but only if 3d)
             if axes_3d:
-                coordinate_inds = [['xs', 'ys', 'zs'].index(q)
+                coordinate_inds = [mesh_coordinates.index(q)
                                    for q in [xqualifier, yqualifier, zqualifier]]
             else:
-                coordinate_inds = [['xs', 'ys', 'zs'].index(q)
+                coordinate_inds = [mesh_coordinates.index(q)
                                    for q in [xqualifier, yqualifier]]
 
             data = vertices_xyz[:, :, coordinate_inds]
@@ -2178,13 +2193,13 @@ class ParameterSet(object):
         # now we can use ps.kind to guess what columns need plotting
         if ps.kind in ['orb', 'orb_syn']:
             if axes_3d:
-                xqualifier = kwargs.get('x', 'xs')
-                yqualifier = kwargs.get('y', 'ys')
-                zqualifier = kwargs.get('z', 'zs')
+                xqualifier = kwargs.get('x', 'us')
+                yqualifier = kwargs.get('y', 'vs')
+                zqualifier = kwargs.get('z', 'ws')
             else:
-                xqualifier = kwargs.get('x', 'xs')
-                yqualifier = kwargs.get('y', 'zs')
-                zqualifier = kwargs.get('z', 'ys')
+                xqualifier = kwargs.get('x', 'us')
+                yqualifier = kwargs.get('y', 'ws')
+                zqualifier = kwargs.get('z', 'vs')
             timequalifier = 'times'
         elif ps.kind in ['mesh', 'mesh_syn']:
             xqualifier = kwargs.get('x', 'r_projs')

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3914,6 +3914,19 @@ class SelectParameter(Parameter):
 
         self._add_history(redo_func='set_value', redo_kwargs={'value': value, 'uniqueid': self.uniqueid}, undo_func='set_value', undo_kwargs={'value': _orig_value, 'uniqueid': self.uniqueid})
 
+    def __add__(self, other):
+        if not isinstance(other, list):
+            return super(SelectParameter, self).__add__(self, other)
+
+        # then we have a list, so we want to append to the existing value
+        return list(set(self.get_value()+other))
+
+    def __sub__(self, other):
+        if not isinstance(other, list):
+            return super(SelectParameter, self).__sub__(self, other)
+
+        return [v for v in self.get_value() if v not in other]
+
 class BoolParameter(Parameter):
     def __init__(self, *args, **kwargs):
         """
@@ -4635,6 +4648,20 @@ class FloatArrayParameter(FloatParameter):
         lst =self.get_value()#.value
         lst[index] = value
         self.set_value(lst)
+
+    def __add__(self, other):
+        if not (isinstance(other, list) or isinstance(other, np.ndarray)):
+            return super(FloatArrayParameter, self).__add__(self, other)
+
+        # then we have a list, so we want to append to the existing value
+        return np.append(self.get_value(), np.asarray(other))
+
+    def __sub__(self, other):
+        if not (isinstance(other, list) or isinstance(other, np.ndarray)):
+            return super(FloatArrayParameter, self).__add__(self, other)
+
+        # then we have a list, so we want to append to the existing value
+        return np.array([v for v in self.get_value() if v not in other])
 
     # def set_value_at_time(self, time, value, **kwargs):
     #     """

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3914,7 +3914,7 @@ class SelectParameter(Parameter):
         _orig_value = deepcopy(self.get_value())
 
         if not isinstance(value, list):
-            raise TypeError("value must be a list of strings, received {}".format(type, value))
+            raise TypeError("value must be a list of strings, received {}".format(type(value)))
 
         try:
             value = [str(v) for v in value]

--- a/tests/nosetests/test_dynamics/test_dynamics.py
+++ b/tests/nosetests/test_dynamics/test_dynamics.py
@@ -19,26 +19,26 @@ def _keplerian_v_nbody(b, plot=False):
     b.set_value('dynamics_method', 'bs')
 
     times = np.linspace(0, 100, 10000)
-    nb_ts, nb_xs, nb_ys, nb_zs, nb_vxs, nb_vys, nb_vzs = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, ltte=False)
-    k_ts, k_xs, k_ys, k_zs, k_vxs, k_vys, k_vzs = phoebe.dynamics.keplerian.dynamics_from_bundle(b, times)
+    nb_ts, nb_us, nb_vs, nb_ws, nb_vus, nb_vvs, nb_vws = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, ltte=False)
+    k_ts, k_us, k_vs, k_ws, k_vus, k_vvs, k_vws = phoebe.dynamics.keplerian.dynamics_from_bundle(b, times)
 
     assert(np.allclose(nb_ts, k_ts, 1e-8))
     for ci in range(len(b.hierarchy.get_stars())):
         # TODO: make atol lower (currently 1e-5 solRad which is awfully big, but 1e-6 currently fails!)
         if plot:
-            print "max atol xs:", nb_xs[ci] - k_xs[ci]
-            print "max atol ys:", nb_ys[ci] - k_ys[ci]
-            print "max atol zs:", nb_zs[ci] - k_zs[ci]
-            print "max atol vxs:", nb_vxs[ci] - k_vxs[ci]
-            print "max atol vys:", nb_vys[ci] - k_vys[ci]
-            print "max atol vzs:", nb_vzs[ci] - k_vzs[ci]
+            print "max atol us:", nb_us[ci] - k_us[ci]
+            print "max atol vs:", nb_vs[ci] - k_vs[ci]
+            print "max atol ws:", nb_ws[ci] - k_ws[ci]
+            print "max atol vus:", nb_vus[ci] - k_vus[ci]
+            print "max atol vvs:", nb_vvs[ci] - k_vvs[ci]
+            print "max atol vws:", nb_vws[ci] - k_vws[ci]
 
-        assert(np.allclose(nb_xs[ci], k_xs[ci], atol=1e-5))
-        assert(np.allclose(nb_ys[ci], k_ys[ci], atol=1e-5))
-        assert(np.allclose(nb_zs[ci], k_zs[ci], atol=1e-5))
-        assert(np.allclose(nb_vxs[ci], k_vxs[ci], atol=1e-4))
-        assert(np.allclose(nb_vys[ci], k_vys[ci], atol=1e-4))
-        assert(np.allclose(nb_vzs[ci], k_vzs[ci], atol=1e-4))
+        assert(np.allclose(nb_us[ci], k_us[ci], atol=1e-5))
+        assert(np.allclose(nb_vs[ci], k_vs[ci], atol=1e-5))
+        assert(np.allclose(nb_ws[ci], k_ws[ci], atol=1e-5))
+        assert(np.allclose(nb_vus[ci], k_vus[ci], atol=1e-4))
+        assert(np.allclose(nb_vvs[ci], k_vvs[ci], atol=1e-4))
+        assert(np.allclose(nb_vws[ci], k_vws[ci], atol=1e-4))
 
 def _phoebe_v_photodynam(b, plot=False):
     """
@@ -66,7 +66,7 @@ def _phoebe_v_photodynam(b, plot=False):
 
 
         if plot:
-            for k in ['xs', 'ys', 'zs', 'vxs', 'vys', 'vzs']:
+            for k in ['us', 'vs', 'ws', 'vus', 'vvs', 'vws']:
                 plt.cla()
                 plt.plot(b.get_value('times', model='phoeberesults', component=comp, unit=u.d), b.get_value(k, model='phoeberesults', component=comp), 'r-')
                 plt.plot(b.get_value('times', model='phoeberesults', component=comp, unit=u.d), b.get_value(k, model='pdresults', component=comp), 'b-')
@@ -77,12 +77,12 @@ def _phoebe_v_photodynam(b, plot=False):
                 plt.show()
 
         assert(np.allclose(b.get_value('times', dataset='orb01', model='phoeberesults', component=comp, unit=u.d), b.get_value('times', dataset='orb01', model='pdresults', component=comp, unit=u.d), atol=1e-6))
-        assert(np.allclose(b.get_value('xs', dataset='orb01', model='phoeberesults', component=comp, unit=u.AU), b.get_value('xs', dataset='orb01', model='pdresults', component=comp, unit=u.AU), atol=1e-6))
-        assert(np.allclose(b.get_value('ys', dataset='orb01', model='phoeberesults', component=comp, unit=u.AU), b.get_value('ys', dataset='orb01', model='pdresults', component=comp, unit=u.AU), atol=1e-6))
-        assert(np.allclose(b.get_value('zs', dataset='orb01', model='phoeberesults', component=comp, unit=u.AU), b.get_value('zs', dataset='orb01', model='pdresults', component=comp, unit=u.AU), atol=1e-6))
-        assert(np.allclose(b.get_value('vxs', dataset='orb01', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vxs', dataset='orb01', model='pdresults', component=comp, unit=u.solRad/u.d), atol=1e-6))
-        assert(np.allclose(b.get_value('vys', dataset='orb01', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vys', dataset='orb01', model='pdresults', component=comp, unit=u.solRad/u.d), atol=1e-6))
-        assert(np.allclose(b.get_value('vzs', dataset='orb01', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vzs', dataset='orb01', model='pdresults', component=comp, unit=u.solRad/u.d), atol=1e-6))
+        assert(np.allclose(b.get_value('us', dataset='orb01', model='phoeberesults', component=comp, unit=u.AU), b.get_value('us', dataset='orb01', model='pdresults', component=comp, unit=u.AU), atol=1e-6))
+        assert(np.allclose(b.get_value('vs', dataset='orb01', model='phoeberesults', component=comp, unit=u.AU), b.get_value('vs', dataset='orb01', model='pdresults', component=comp, unit=u.AU), atol=1e-6))
+        assert(np.allclose(b.get_value('ws', dataset='orb01', model='phoeberesults', component=comp, unit=u.AU), b.get_value('ws', dataset='orb01', model='pdresults', component=comp, unit=u.AU), atol=1e-6))
+        assert(np.allclose(b.get_value('vus', dataset='orb01', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vus', dataset='orb01', model='pdresults', component=comp, unit=u.solRad/u.d), atol=1e-6))
+        assert(np.allclose(b.get_value('vvs', dataset='orb01', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vvs', dataset='orb01', model='pdresults', component=comp, unit=u.solRad/u.d), atol=1e-6))
+        assert(np.allclose(b.get_value('vws', dataset='orb01', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vws', dataset='orb01', model='pdresults', component=comp, unit=u.solRad/u.d), atol=1e-6))
 
 def _frontend_v_backend(b, plot=False):
     """
@@ -99,7 +99,7 @@ def _frontend_v_backend(b, plot=False):
 
     # NBODY
     # do backend Nbody
-    b_ts, b_xs, b_ys, b_zs, b_vxs, b_vys, b_vzs = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, compute='nbody')
+    b_ts, b_us, b_vs, b_ws, b_vus, b_vvs, b_vws = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, compute='nbody')
 
     # do frontend Nbody
     b.run_compute('nbody', model='nbodyresults')
@@ -108,12 +108,12 @@ def _frontend_v_backend(b, plot=False):
     for ci,comp in enumerate(b.hierarchy.get_stars()):
         # TODO: can we lower tolerance?
         assert(np.allclose(b.get_value('times', dataset='orb01', model='nbodyresults', component=comp, unit=u.d), b_ts, atol=1e-6))
-        assert(np.allclose(b.get_value('xs', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad), b_xs[ci], atol=1e-5))
-        assert(np.allclose(b.get_value('ys', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad), b_ys[ci], atol=1e-5))
-        assert(np.allclose(b.get_value('zs', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad), b_zs[ci], atol=1e-5))
-        assert(np.allclose(b.get_value('vxs', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vxs[ci], atol=1e-4))
-        assert(np.allclose(b.get_value('vys', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vys[ci], atol=1e-4))
-        assert(np.allclose(b.get_value('vzs', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vzs[ci], atol=1e-4))
+        assert(np.allclose(b.get_value('us', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad), b_us[ci], atol=1e-5))
+        assert(np.allclose(b.get_value('vs', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad), b_vs[ci], atol=1e-5))
+        assert(np.allclose(b.get_value('ws', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad), b_ws[ci], atol=1e-5))
+        assert(np.allclose(b.get_value('vus', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vus[ci], atol=1e-4))
+        assert(np.allclose(b.get_value('vvs', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vvs[ci], atol=1e-4))
+        assert(np.allclose(b.get_value('vws', dataset='orb01', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vws[ci], atol=1e-4))
 
 
 
@@ -131,12 +131,12 @@ def _frontend_v_backend(b, plot=False):
     for ci,comp in enumerate(b.hierarchy.get_stars()):
         # TODO: can we lower tolerance?
         assert(np.allclose(b.get_value('times', dataset='orb01', model='keplerianresults', component=comp, unit=u.d), b_ts, atol=1e-6))
-        assert(np.allclose(b.get_value('xs', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad), b_xs[ci], atol=1e-5))
-        assert(np.allclose(b.get_value('ys', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad), b_ys[ci], atol=1e-5))
-        assert(np.allclose(b.get_value('zs', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad), b_zs[ci], atol=1e-5))
-        assert(np.allclose(b.get_value('vxs', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vxs[ci], atol=1e-4))
-        assert(np.allclose(b.get_value('vys', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vys[ci], atol=1e-4))
-        assert(np.allclose(b.get_value('vzs', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vzs[ci], atol=1e-4))
+        assert(np.allclose(b.get_value('us', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad), b_us[ci], atol=1e-5))
+        assert(np.allclose(b.get_value('vs', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad), b_vs[ci], atol=1e-5))
+        assert(np.allclose(b.get_value('ws', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad), b_ws[ci], atol=1e-5))
+        assert(np.allclose(b.get_value('vus', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vus[ci], atol=1e-4))
+        assert(np.allclose(b.get_value('vvs', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vvs[ci], atol=1e-4))
+        assert(np.allclose(b.get_value('vws', dataset='orb01', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vws[ci], atol=1e-4))
 
 
 

--- a/tests/nosetests/test_dynamics/test_dynamics_grid.py
+++ b/tests/nosetests/test_dynamics/test_dynamics_grid.py
@@ -19,21 +19,21 @@ def _keplerian_v_nbody(b, ltte, period, plot=False):
     b.set_value('dynamics_method', 'bs')
 
     times = np.linspace(0, 5*period, 101)
-    nb_ts, nb_xs, nb_ys, nb_zs, nb_vxs, nb_vys, nb_vzs = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, ltte=ltte)
-    k_ts, k_xs, k_ys, k_zs, k_vxs, k_vys, k_vzs = phoebe.dynamics.keplerian.dynamics_from_bundle(b, times, ltte=ltte)
+    nb_ts, nb_us, nb_vs, nb_ws, nb_vus, nb_vvs, nb_vws = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, ltte=ltte)
+    k_ts, k_us, k_vs, k_ws, k_vus, k_vvs, k_vws = phoebe.dynamics.keplerian.dynamics_from_bundle(b, times, ltte=ltte)
 
     assert(np.allclose(nb_ts, k_ts, 1e-8))
     for ci in range(len(b.hierarchy.get_stars())):
         # TODO: make rtol lower if possible
-        assert(np.allclose(nb_xs[ci], k_xs[ci], rtol=1e-5, atol=1e-2))
-        assert(np.allclose(nb_ys[ci], k_ys[ci], rtol=1e-5, atol=1e-2))
-        assert(np.allclose(nb_zs[ci], k_zs[ci], rtol=1e-5, atol=1e-2))
+        assert(np.allclose(nb_us[ci], k_us[ci], rtol=1e-5, atol=1e-2))
+        assert(np.allclose(nb_vs[ci], k_vs[ci], rtol=1e-5, atol=1e-2))
+        assert(np.allclose(nb_ws[ci], k_ws[ci], rtol=1e-5, atol=1e-2))
 
         # nbody ltte velocities are wrong so only check velocities if ltte off
         if not ltte:
-            assert(np.allclose(nb_vxs[ci], k_vxs[ci], rtol=1e-5, atol=1e-2))
-            assert(np.allclose(nb_vys[ci], k_vys[ci], rtol=1e-5, atol=1e-2))
-            assert(np.allclose(nb_vzs[ci], k_vzs[ci], rtol=1e-5, atol=1e-2))
+            assert(np.allclose(nb_vus[ci], k_vus[ci], rtol=1e-5, atol=1e-2))
+            assert(np.allclose(nb_vvs[ci], k_vvs[ci], rtol=1e-5, atol=1e-2))
+            assert(np.allclose(nb_vws[ci], k_vws[ci], rtol=1e-5, atol=1e-2))
 
 def _phoebe_v_photodynam(b, period, plot=False):
     """
@@ -60,7 +60,7 @@ def _phoebe_v_photodynam(b, period, plot=False):
 
 
         if plot:
-            for k in ['xs', 'ys', 'zs', 'vxs', 'vys', 'vzs']:
+            for k in ['us', 'vs', 'ws', 'vus', 'vvs', 'vws']:
                 plt.cla()
                 plt.plot(b.get_value('times', model='phoeberesults', component=comp, unit=u.d), b.get_value(k, model='phoeberesults', component=comp), 'r-')
                 plt.plot(b.get_value('times', model='phoeberesults', component=comp, unit=u.d), b.get_value(k, model='pdresults', component=comp), 'b-')
@@ -71,9 +71,9 @@ def _phoebe_v_photodynam(b, period, plot=False):
                 plt.show()
 
         assert(np.allclose(b.get_value('times', model='phoeberesults', component=comp, unit=u.d), b.get_value('times', model='pdresults', component=comp, unit=u.d), rtol=0, atol=1e-05))
-        assert(np.allclose(b.get_value('xs', model='phoeberesults', component=comp, unit=u.AU), b.get_value('xs', model='pdresults', component=comp, unit=u.AU), rtol=0, atol=1e-05))
-        assert(np.allclose(b.get_value('ys', model='phoeberesults', component=comp, unit=u.AU), b.get_value('ys', model='pdresults', component=comp, unit=u.AU), rtol=0, atol=1e-05))
-        assert(np.allclose(b.get_value('zs', model='phoeberesults', component=comp, unit=u.AU), b.get_value('zs', model='pdresults', component=comp, unit=u.AU), rtol=0, atol=1e-05))
+        assert(np.allclose(b.get_value('us', model='phoeberesults', component=comp, unit=u.AU), b.get_value('us', model='pdresults', component=comp, unit=u.AU), rtol=0, atol=1e-05))
+        assert(np.allclose(b.get_value('vs', model='phoeberesults', component=comp, unit=u.AU), b.get_value('vs', model='pdresults', component=comp, unit=u.AU), rtol=0, atol=1e-05))
+        assert(np.allclose(b.get_value('ws', model='phoeberesults', component=comp, unit=u.AU), b.get_value('ws', model='pdresults', component=comp, unit=u.AU), rtol=0, atol=1e-05))
         #assert(np.allclose(b.get_value('vxs', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vxs', model='pdresults', component=comp, unit=u.solRad/u.d), rtol=0, atol=1e-05))
         #assert(np.allclose(b.get_value('vys', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vys', model='pdresults', component=comp, unit=u.solRad/u.d), rtol=0, atol=1e-05))
         #assert(np.allclose(b.get_value('vzs', model='phoeberesults', component=comp, unit=u.solRad/u.d), b.get_value('vzs', model='pdresults', component=comp, unit=u.solRad/u.d), rtol=0, atol=1e-05))
@@ -93,7 +93,7 @@ def _frontend_v_backend(b, ltte, period, plot=False):
 
     # NBODY
     # do backend Nbody
-    b_ts, b_xs, b_ys, b_zs, b_vxs, b_vys, b_vzs = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, compute='nbody', ltte=ltte)
+    b_ts, b_us, b_vs, b_ws, b_vus, b_vvs, b_vws = phoebe.dynamics.nbody.dynamics_from_bundle(b, times, compute='nbody', ltte=ltte)
 
     # do frontend Nbody
     b.run_compute('nbody', model='nbodyresults')
@@ -102,20 +102,20 @@ def _frontend_v_backend(b, ltte, period, plot=False):
     for ci,comp in enumerate(b.hierarchy.get_stars()):
         # TODO: can we lower tolerance?
         assert(np.allclose(b.get_value('times', model='nbodyresults', component=comp, unit=u.d), b_ts, rtol=0, atol=1e-6))
-        assert(np.allclose(b.get_value('xs', model='nbodyresults', component=comp, unit=u.solRad), b_xs[ci], rtol=1e-7, atol=1e-4))
-        assert(np.allclose(b.get_value('ys', model='nbodyresults', component=comp, unit=u.solRad), b_ys[ci], rtol=1e-7, atol=1e-4))
-        assert(np.allclose(b.get_value('zs', model='nbodyresults', component=comp, unit=u.solRad), b_zs[ci], rtol=1e-7, atol=1e-4))
+        assert(np.allclose(b.get_value('us', model='nbodyresults', component=comp, unit=u.solRad), b_us[ci], rtol=1e-7, atol=1e-4))
+        assert(np.allclose(b.get_value('vs', model='nbodyresults', component=comp, unit=u.solRad), b_vs[ci], rtol=1e-7, atol=1e-4))
+        assert(np.allclose(b.get_value('ws', model='nbodyresults', component=comp, unit=u.solRad), b_ws[ci], rtol=1e-7, atol=1e-4))
         if not ltte:
-            assert(np.allclose(b.get_value('vxs', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vxs[ci], rtol=1e-7, atol=1e-4))
-            assert(np.allclose(b.get_value('vys', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vys[ci], rtol=1e-7, atol=1e-4))
-            assert(np.allclose(b.get_value('vzs', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vzs[ci], rtol=1e-7, atol=1e-4))
+            assert(np.allclose(b.get_value('vus', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vus[ci], rtol=1e-7, atol=1e-4))
+            assert(np.allclose(b.get_value('vvs', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vvs[ci], rtol=1e-7, atol=1e-4))
+            assert(np.allclose(b.get_value('vws', model='nbodyresults', component=comp, unit=u.solRad/u.d), b_vws[ci], rtol=1e-7, atol=1e-4))
 
 
 
 
     # KEPLERIAN
     # do backend keplerian
-    b_ts, b_xs, b_ys, b_zs, b_vxs, b_vys, b_vzs = phoebe.dynamics.keplerian.dynamics_from_bundle(b, times, compute='keplerian', ltte=ltte)
+    b_ts, b_us, b_vs, b_ws, b_vus, b_vvs, b_vws = phoebe.dynamics.keplerian.dynamics_from_bundle(b, times, compute='keplerian', ltte=ltte)
 
 
     # do frontend keplerian
@@ -126,12 +126,12 @@ def _frontend_v_backend(b, ltte, period, plot=False):
     for ci,comp in enumerate(b.hierarchy.get_stars()):
         # TODO: can we lower tolerance?
         assert(np.allclose(b.get_value('times', model='keplerianresults', component=comp, unit=u.d), b_ts, rtol=0, atol=1e-08))
-        assert(np.allclose(b.get_value('xs', model='keplerianresults', component=comp, unit=u.solRad), b_xs[ci], rtol=0, atol=1e-08))
-        assert(np.allclose(b.get_value('ys', model='keplerianresults', component=comp, unit=u.solRad), b_ys[ci], rtol=0, atol=1e-08))
-        assert(np.allclose(b.get_value('zs', model='keplerianresults', component=comp, unit=u.solRad), b_zs[ci], rtol=0, atol=1e-08))
-        assert(np.allclose(b.get_value('vxs', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vxs[ci], rtol=0, atol=1e-08))
-        assert(np.allclose(b.get_value('vys', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vys[ci], rtol=0, atol=1e-08))
-        assert(np.allclose(b.get_value('vzs', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vzs[ci], rtol=0, atol=1e-08))
+        assert(np.allclose(b.get_value('us', model='keplerianresults', component=comp, unit=u.solRad), b_us[ci], rtol=0, atol=1e-08))
+        assert(np.allclose(b.get_value('vs', model='keplerianresults', component=comp, unit=u.solRad), b_vs[ci], rtol=0, atol=1e-08))
+        assert(np.allclose(b.get_value('ws', model='keplerianresults', component=comp, unit=u.solRad), b_ws[ci], rtol=0, atol=1e-08))
+        assert(np.allclose(b.get_value('vus', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vus[ci], rtol=0, atol=1e-08))
+        assert(np.allclose(b.get_value('vvs', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vvs[ci], rtol=0, atol=1e-08))
+        assert(np.allclose(b.get_value('vws', model='keplerianresults', component=comp, unit=u.solRad/u.d), b_vws[ci], rtol=0, atol=1e-08))
 
 
 

--- a/tests/nosetests/test_mesh/test_mesh.py
+++ b/tests/nosetests/test_mesh/test_mesh.py
@@ -15,6 +15,7 @@ def _phoebe_v_legacy_lc_protomesh(b, gridsize=50, plot=False):
     b = phoebe.Bundle.default_binary()
 
     b.add_dataset('lc', times=[0], dataset='lc01')
+    b.add_dataset('mesh', include_times='lc01', dataset='mesh01', columns=['abs_normal_intensities@*', 'loggs', 'teffs', 'us'])
 
     b.add_compute('legacy', compute='phoebe1')
     b.add_compute('phoebe', compute='phoebe2')
@@ -29,22 +30,22 @@ def _phoebe_v_legacy_lc_protomesh(b, gridsize=50, plot=False):
     # TODO: also compare phoebe1:kurucz to phoebe:extern_atmx
     b.set_value_all('atm', 'extern_planckint')
 
-    b.run_compute('phoebe1', model='phoebe1model', protomesh=True, pbmesh=True, refl_num=0)
-    b.run_compute('phoebe2', model='phoebe2model', protomesh=True, pbmesh=True, irrad_method='none')
+    b.run_compute('phoebe1', model='phoebe1model', refl_num=0)
+    b.run_compute('phoebe2', model='phoebe2model', irrad_method='none')
 
 
     compares = []
-    # compares += [{'qualifier': 'xs', 'dataset': 'protomesh', 'atol': 1e-10}]
-    # compares += [{'qualifier': 'ys', 'dataset': 'protomesh', 'atol': 1e-12}]
-    # compares += [{'qualifier': 'zs', 'dataset': 'protomesh', 'atol': 1e-11}]
-    # compares += [{'qualifier': 'rs', 'dataset': 'protomesh', 'atol': 1e-10}]
-    # compares += [{'qualifier': 'nxs', 'dataset': 'protomesh', 'atol': 1e-7}]
-    # compares += [{'qualifier': 'nys', 'dataset': 'protomesh', 'atol': 1e-9}]
-    # compares += [{'qualifier': 'nzs', 'dataset': 'protomesh', 'atol': 1e-8}]
-    # compares += [{'qualifier': 'cosbetas', 'dataset': 'protomesh', 'atol': 1e-14}]
+    # compares += [{'qualifier': 'us', 'dataset': 'mesh01', 'atol': 1e-10}]
+    # compares += [{'qualifier': 'vs', 'dataset': 'mesh01', 'atol': 1e-12}]
+    # compares += [{'qualifier': 'ws', 'dataset': 'mesh01', 'atol': 1e-11}]
+    # compares += [{'qualifier': 'rs', 'dataset': 'mesh01', 'atol': 1e-10}]
+    # compares += [{'qualifier': 'nus', 'dataset': 'mesh01', 'atol': 1e-7}]
+    # compares += [{'qualifier': 'nvs', 'dataset': 'mesh01', 'atol': 1e-9}]
+    # compares += [{'qualifier': 'nws', 'dataset': 'mesh01', 'atol': 1e-8}]
+    # compares += [{'qualifier': 'cosbetas', 'dataset': 'mesh01', 'atol': 1e-14}]
 
-    compares += [{'qualifier': 'loggs', 'dataset': 'protomesh', 'atol': 2e-4}]
-    compares += [{'qualifier': 'teffs', 'dataset': 'protomesh', 'atol': 1e-5}]
+    compares += [{'qualifier': 'loggs', 'dataset': 'mesh01', 'atol': 2e-4}]
+    compares += [{'qualifier': 'teffs', 'dataset': 'mesh01', 'atol': 1e-5}]
 
     compares += [{'qualifier': 'abs_normal_intensities', 'dataset': 'lc01', 'atol': 2e5}] # NOTE: these values are of order 1E14
 
@@ -61,38 +62,29 @@ def _phoebe_v_legacy_lc_protomesh(b, gridsize=50, plot=False):
 
             if component=='secondary':
                 # TODO: this logic should /REALLY/ be moved into the legacy backend wrapper
-                if qualifier in ['xs']:
+                if qualifier in ['us']:
                     # the secondary star from phoebe 1 is at (d=a=1, 0, 0)
                     phoebe2_val -= 1
-                if qualifier in ['xs', 'ys', 'nxs', 'nys']:
+                if qualifier in ['us', 'vs', 'nus', 'nvs']:
                     # the secondary star from phoebe1 is rotated about the z-axis
                     phoebe2_val *= -1
-
-
-            # TODO: handle the hemispheres correctly in the legacy backend and remove this [::8] stuff (also below in plotting)
-            if dataset=='protomesh':
-                phoebe1_val = phoebe1_val[::4]
-                phoebe2_val = phoebe2_val[::8]
 
 
             if plot:
                 print "{}@{}@{} max diff: {}".format(qualifier, component, dataset, max(np.abs(phoebe1_val-phoebe2_val)))
 
             if plot:
-                x = b.get_value(section='model', model='phoebe2model', component=component, dataset='protomesh', qualifier='xs')
-
-                if dataset=='protomesh':
-                    x = x[::8]
+                x = b.get_value(section='model', model='phoebe2model', component=component, dataset='mesh01', qualifier='us')
 
                 fig, (ax1, ax2) = plt.subplots(1,2)
-                print 'comps', len(x), len(phoebe1_val)
+                print 'comps', len(x), len(phoebe1_val), len(phoebe2_val)
                 ax1.plot(x, phoebe1_val, 'bo')
                 ax1.plot(x, phoebe2_val, 'r.')
 
                 ax2.plot(x, phoebe1_val-phoebe2_val, 'k.')
 
-                ax1.set_xlabel('{}@{} (phoebe2)'.format('x', component))
-                ax2.set_xlabel('{}@{} (phoebe2)'.format('x', component))
+                ax1.set_xlabel('{}@{} (phoebe2)'.format('u', component))
+                ax2.set_xlabel('{}@{} (phoebe2)'.format('u', component))
 
                 ax1.set_ylabel('{}@{} (blue=phoebe1, red=phoebe2)'.format(qualifier, component))
                 ax2.set_ylabel('{}@{} (phoebe1-phoebe2)'.format(qualifier, component))

--- a/tests/nosetests/test_mesh/test_mesh.py
+++ b/tests/nosetests/test_mesh/test_mesh.py
@@ -61,14 +61,13 @@ def _phoebe_v_legacy_lc_protomesh(b, gridsize=50, plot=False):
             phoebe2_val = b.get_value(section='model', model='phoebe2model', component=component, dataset=dataset, qualifier=qualifier)
 
 
-            if dataset=='mesh01':
-                # phoebe2 wd-style mesh duplicates each trapezoid into two
-                # triangles, so we only need every other.  It also handles
-                # duplicating quadrants per-element, whereas the phoebe1
-                # wrapper duplicates per-quadrant.  So we also need to reshape.
-                # TODO: move this into the order that these are actually
-                # exposed by PHOEBE to the user
-                phoebe2_val = phoebe2_val[::2].reshape(-1,4).flatten(order='F')
+            # phoebe2 wd-style mesh duplicates each trapezoid into two
+            # triangles, so we only need every other.  It also handles
+            # duplicating quadrants per-element, whereas the phoebe1
+            # wrapper duplicates per-quadrant.  So we also need to reshape.
+            # TODO: move this into the order that these are actually
+            # exposed by PHOEBE to the user
+            phoebe2_val = phoebe2_val[::2].reshape(-1,4).flatten(order='F')
 
             if component=='secondary':
                 # TODO: this logic should /REALLY/ be moved into the legacy backend wrapper
@@ -83,7 +82,7 @@ def _phoebe_v_legacy_lc_protomesh(b, gridsize=50, plot=False):
             if plot:
                 print "{}@{}@{} max diff: {}".format(qualifier, component, dataset, max(np.abs(phoebe1_val-phoebe2_val)))
 
-            if plot and dataset=='mesh01':
+            if plot:
                 x1 = b.get_value(section='model', model='phoebe1model', component=component, dataset='mesh01', qualifier='xs')
                 # x2 = b.get_value(section='model', model='phoebe2model', component=component, dataset='mesh01', qualifier='xs')[::2]
 

--- a/tests/nosetests/test_single/test_single.py
+++ b/tests/nosetests/test_single/test_single.py
@@ -24,19 +24,19 @@ def test_sun(plot=False):
     assert(b.get_value('distance', u.m)==1.0*u.AU.to(u.m))
 
     b.add_dataset('lc', pblum=1*u.solLum)
-    
-    b.run_compute(protomesh=True, pbmesh=True, irrad_method='none', distortion_method='rotstar')
-       
+    b.add_dataset('mesh', columns=['teffs', 'areas', 'rpole'], dataset='mesh01')
+
+    b.run_compute(irrad_method='none', distortion_method='rotstar')
+
     #print abs(b.get_value('teffs', dataset='pbmesh').mean()-b.get_value('teff', context='component'))
-    
-    assert(abs(np.average(b.get_value('teffs', dataset='pbmesh'), weights=b.get_value('areas', dataset='pbmesh')) - b.get_value('teff', context='component')) < 1e-6)
-    assert(abs(b.get_value('rpole', dataset='pbmesh')-b.get_value('rpole', context='component')) < 1e-6)
-    
+
+    assert(abs(np.average(b.get_value('teffs', dataset='mesh01'), weights=b.get_value('areas', dataset='mesh01')) - b.get_value('teff', context='component')) < 1e-6)
+    assert(abs(b.get_value('rpole', dataset='mesh01')-b.get_value('rpole', context='component')) < 1e-6)
+
     #print abs(b.get_value('fluxes@model')[0]-1357.12228578)
-    
+
     if plot:
-        axs, artists = b['protomesh'].plot(facecolor='teffs', show=True)
-        axs, artists = b['pbmesh'].plot(facecolor='teffs', show=True)
+        axs, artists = b['mesh01'].plot(facecolor='teffs', show=True)
 
     return b
 


### PR DESCRIPTION
mesh datasets now have 'columns' and 'include_times' Parameters.  The requested columns are then computed and exposed whether or not those times are already set to be computed by the referenced passband-dependent datasets (i.e., lcs or rvs).  

This allows for meshes to be much more lightweight by default but still allowing the flexibility of exposing "advanced" per-element columns and also hopefully makes more intuitive sense to the user.

This all replaces the previous use of 'protomesh' and 'pbmesh' as compute options and will require some updates to the tutorials/documentation on the next release.