### PR TITLE
MPI detection hotfix (2.1.1 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.1.1 - MPI detection hotfix
+
+* PHOEBE now detects if its within MPI on various different MPI installations (previously only worked for openmpi).
+
 ### 2.1.0 - misalignment feature release
 
 * Add support for spin-orbit misalignment
@@ -140,7 +144,7 @@ CHANGELOG
 
 * Definition of flux and luminosity now use ptfarea instead of pbspan.  In the bolometric case, these give the same quantity. This discrepancy was absorbed entirely by pblum scaling, so relative fluxes should not be affected, but the underlying absolute luminosities were incorrect for passbands (non-bolometric).  In addition to under-the-hood changes, the exposed mesh column for 'pbspan' is now removed and replaced with 'ptfarea', but as this is not yet a documented column, should not cause backwards-compatibility issues.  
 
-### 2.0.0
+### 2.0.0 - official release of PHOEBE 2.0
 
 * PHOEBE 2.0 is not backwards compatible with PHOEBE 2.0-beta (although the interface has not changed appreciably) or with PHOEBE 2.0-alpha (substantial rewrite). Going forward with incremental releases, every effort will be put into backwards compatibility. The changes and important considerations of the new version will be detailed in the ChangeLog.
 

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -10,7 +10,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.1.0'
+__version__ = '2.1.1'
 
 import os
 import sys as _sys

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -78,7 +78,7 @@ class MPI(object):
         # this is a bit of a hack and will only work with openmpi, but environment
         # variables seem to be the only way to detect whether the script was run
         # via mpirun or not
-        if 'OMPI_COMM_WORLD_SIZE' in os.environ.keys():
+        if 'OMPI_COMM_WORLD_SIZE' in os.environ.keys() or 'MPICH_INTERFACE_HOSTNAME' in os.environ.keys():
             from mpi4py import MPI as mpi4py
             self._within_mpirun = True
             self._internal_mpi = True

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -78,7 +78,8 @@ class MPI(object):
         # this is a bit of a hack and will only work with openmpi, but environment
         # variables seem to be the only way to detect whether the script was run
         # via mpirun or not
-        if 'OMPI_COMM_WORLD_SIZE' in os.environ.keys() or 'MPICH_INTERFACE_HOSTNAME' in os.environ.keys():
+        evars = os.environ.keys()
+        if 'OMPI_COMM_WORLD_SIZE' in evars or 'MV2_COMM_WORLD_SIZE' in evars or 'PMI_SIZE' in evars:
             from mpi4py import MPI as mpi4py
             self._within_mpirun = True
             self._internal_mpi = True

--- a/setup.py
+++ b/setup.py
@@ -308,12 +308,12 @@ ext_modules = [
 # Main setup
 #
 setup (name = 'phoebe',
-       version = '2.1.0',
-       description = 'PHOEBE 2.1.0',
+       version = '2.1.1',
+       description = 'PHOEBE 2.1.1',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.0',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.1',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
PHOEBE now checks against the following three environment variables to detect whether it is within an mpi environment: OMPI_COMM_WORLD_SIZE, MV2_COMM_WORLD_SIZE, and PMI_SIZE.