### PR TITLE
constraints in solar units bugfix (2.1.2 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.1.2 - Constraints in solar units hotfix
+
+* All constraints are now executed (by default) in solar units instead of SI.  The Kepler's third law constraint (constraining mass by default) failed to have sufficient precision in SI, resulting in inaccurate masses.  Furthermore, if the constraint was flipped, inaccurate values of sma could be passed to the backend, resulting in overflow in the semi-detached case.
+* Bundles created before 2.1.2 and imported into 2.1.2+ will continue to use SI units for constraints and should function fine, but will not benefit from this update and will be incapable of changing the system hierarchy.
+
 ### 2.1.1 - MPI detection hotfix
 
 * PHOEBE now detects if its within MPI on various different MPI installations (previously only worked for openmpi).

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -10,7 +10,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.1.0'
+__version__ = 'devel'
 
 import os
 import sys as _sys

--- a/phoebe/dependencies/unitsiau2015/__init__.py
+++ b/phoebe/dependencies/unitsiau2015/__init__.py
@@ -129,6 +129,8 @@ TODO: eventually consider adopting this as a "base" unit
 """
 _physical_types_to_solar = {'length': 'solRad',
                             'mass': 'solMass',
+                            'temperature', 'solTeff',
+                            'power', 'solLum',
                             'time': 'd',
                             'speed': 'solRad/d',
                             'angle': 'rad',

--- a/phoebe/dependencies/unitsiau2015/__init__.py
+++ b/phoebe/dependencies/unitsiau2015/__init__.py
@@ -129,8 +129,8 @@ TODO: eventually consider adopting this as a "base" unit
 """
 _physical_types_to_solar = {'length': 'solRad',
                             'mass': 'solMass',
-                            'temperature', 'solTeff',
-                            'power', 'solLum',
+                            'temperature': 'solTeff',
+                            'power': 'solLum',
                             'time': 'd',
                             'speed': 'solRad/d',
                             'angle': 'rad',

--- a/phoebe/dependencies/unitsiau2015/__init__.py
+++ b/phoebe/dependencies/unitsiau2015/__init__.py
@@ -121,6 +121,56 @@ solTeff = def_unit(['solTeff', 'T_sun', 'Tsun'], c.si.T_sun, namespace=ns,
 
 _register_unit(solTeff)
 
+"""
+astropy also doesn't have any ability to convert to solar units, so we'll provide
+a function for that.
+
+TODO: eventually consider adopting this as a "base" unit
+"""
+_physical_types_to_solar = {'length': 'solRad',
+                            'mass': 'solMass',
+                            'time': 'd',
+                            'speed': 'solRad/d',
+                            'dimensionless': ''}
+
+def _get_physical_type(object):
+    if isinstance(object, u.Quantity):
+        unit = object.unit
+    elif isinstance(object, u.Unit):
+        unit = object
+    else:
+        raise NotImplementedError
+
+    return unit.physical_type
+
+def can_convert_to_solar(object):
+    return _get_physical_type(object) in _physical_types_to_solar.keys()
+
+def to_solar(object):
+    """
+    Arguments
+    ----------
+    * `object` (quantity or unit)
+
+    Returns
+    ----------
+    * quantity or unit in applicable solar units
+
+    Raises
+    --------
+    * NotImplementedError: if cannot convert to solar
+    """
+    physical_type = _get_physical_type(object)
+
+    if physical_type not in _physical_types_to_solar.keys():
+        raise NotImplementedError("cannot convert object with physical_type={} to solar units".format(physical_type))
+
+    return object.to(_physical_types_to_solar.get(physical_type))
+
+u.can_convert_to_solar = can_convert_to_solar
+u.to_solar = to_solar
+
+
 
 """
 And lastly, let's do all remaining cleanup

--- a/phoebe/dependencies/unitsiau2015/__init__.py
+++ b/phoebe/dependencies/unitsiau2015/__init__.py
@@ -131,15 +131,18 @@ _physical_types_to_solar = {'length': 'solRad',
                             'mass': 'solMass',
                             'time': 'd',
                             'speed': 'solRad/d',
+                            'angle': 'rad',
+                            'angular speed': 'rad/d',
                             'dimensionless': ''}
 
 def _get_physical_type(object):
-    if isinstance(object, u.Quantity):
-        unit = object.unit
-    elif isinstance(object, u.Unit):
+
+    if hasattr(object, 'physical_type'):
         unit = object
+    elif isinstance(object, u.Quantity):
+        unit = object.unit
     else:
-        raise NotImplementedError
+        raise NotImplementedError("object {} with type={} not supported for _get_physical_type".format(object, type(object)))
 
     return unit.physical_type
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -202,6 +202,7 @@ class Bundle(ParameterSet):
         if phoebe_version_import == phoebe_version_this:
             return b
         elif phoebe_version_import > phoebe_version_this:
+            print("WARNING: importing from a newer version ({}) of PHOEBE, this may or may not work, consider updating")
             logger.warning("importing from a newer version ({}) of PHOEBE, this may or may not work, consider updating".format(phoebe_version_import))
             return b
         elif phoebe_version_import < StrictVersion("2.1.0"):

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -2567,6 +2567,7 @@ class Bundle(ParameterSet):
                                                model=lhs.model,
                                                constraint_func=func.__name__,
                                                constraint_kwargs=constraint_kwargs,
+                                               in_solar_units=func.__name__=='mass',
                                                value=rhs,
                                                default_unit=lhs.default_unit,
                                                description='expression that determines the constraint')

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -2567,7 +2567,7 @@ class Bundle(ParameterSet):
                                                model=lhs.model,
                                                constraint_func=func.__name__,
                                                constraint_kwargs=constraint_kwargs,
-                                               in_solar_units=func.__name__=='mass',
+                                               in_solar_units=func.__name__ not in constraint.list_of_constraints_requiring_si,
                                                value=rhs,
                                                default_unit=lhs.default_unit,
                                                description='expression that determines the constraint')

--- a/phoebe/parameters/constraint.py
+++ b/phoebe/parameters/constraint.py
@@ -651,7 +651,7 @@ def keplers_third_law_hierarchical(b, orbit1, orbit2, solve_for=None, **kwargs):
 
     if solve_for in [None, sma1]:
         lhs = sma1
-        rhs = (sma2**3 * qthing1 * period1**2/period2**2)**(1./3)
+        rhs = (sma2**3 * qthing1 * period1**2/period2**2)**"(1./3)"
     else:
         # TODO: add other options to solve_for
         raise NotImplementedError
@@ -772,12 +772,12 @@ def mass(b, component, solve_for=None, **kwargs):
     elif solve_for==sma:
 
         lhs = sma
-        rhs = ((mass * period**2 * qthing * G)/(4 * np.pi**2))**(1./3)
+        rhs = ((mass * period**2 * qthing * G)/(4 * np.pi**2))**"(1./3)"
 
     elif solve_for==period:
 
         lhs = period
-        rhs = ((4 * np.pi**2 * sma**3)/(mass * qthing * G))**(1./2)
+        rhs = ((4 * np.pi**2 * sma**3)/(mass * qthing * G))**"(1./2)"
 
     elif solve_for==q:
         # TODO: implement this so that one mass can be solved for sma and the

--- a/phoebe/parameters/constraint.py
+++ b/phoebe/parameters/constraint.py
@@ -8,6 +8,8 @@ import logging
 logger = logging.getLogger("CONSTRAINT")
 logger.addHandler(logging.NullHandler())
 
+list_of_constraints_requiring_si = []
+
 
 def _get_system_ps(b, item, context='component'):
     """

--- a/phoebe/parameters/constraint.py
+++ b/phoebe/parameters/constraint.py
@@ -757,6 +757,7 @@ def mass(b, component, solve_for=None, **kwargs):
     q = b.get_parameter(qualifier='q', **metawargs)
 
     G = c.G.to('solRad3 / (solMass d2)')
+    G.keep_in_solar_units = True
 
     if hier.get_primary_or_secondary(component) == 'primary':
         qthing = 1.0+q

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -5527,6 +5527,8 @@ class ConstraintParameter(Parameter):
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
             return ConstraintParameter(self._bundle, "(%s) %s %f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
+        elif isinstance(other, str):
+            return ConstraintParameter(self._bundle, "(%s) %s %s" % (self.expr, symbol, other), default_unit=(getattr(self.result, mathfunc)(eval(other)).unit))
         elif _is_unit(other) and mathfunc=='__mul__':
             # here we'll fake the unit to become a quantity so that we still return a ConstraintParameter
             return self*(1*other)
@@ -5551,6 +5553,8 @@ class ConstraintParameter(Parameter):
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
             return ConstraintParameter(self._bundle, "%f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
+        elif isinstance(other, str):
+            return ConstraintParameter(self._bundle, "%s %s (%s)" % (other, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(eval(other)).unit))
         elif _is_unit(other) and mathfunc=='__mul__':
             # here we'll fake the unit to become a quantity so that we still return a ConstraintParameter
             return self*(1*other)

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -234,6 +234,16 @@ def _uniqueid(n=30):
 def _is_unit(unit):
     return isinstance(unit, u.Unit) or isinstance(unit, u.CompositeUnit) or isinstance(unit, u.IrreducibleUnit)
 
+def _value_for_constraint(item, constraintparam=None):
+    if getattr(item, 'keep_in_solar_units', False):
+        # for example, constants defined in the constraint itself can have
+        # this attribute added to force them to stay in solar units in the constraint
+        return item.value
+    elif constraintparam is not None and constraintparam.in_solar_units:
+        return u.to_solar(item).value
+    else:
+        return item.si.value
+
 
 def parameter_from_json(dictionary, bundle=None):
     """Load a single parameter from a JSON dictionary.
@@ -3455,6 +3465,8 @@ class Parameter(object):
     def __math__(self, other, symbol, mathfunc):
         """
         """
+
+
         try:
             # print "***", type(other), mathfunc
             if isinstance(other, ConstraintParameter):
@@ -3478,8 +3490,7 @@ class Parameter(object):
                 default_unit = getattr(self_quantity, mathfunc)(other_quantity).unit
                 return ConstraintParameter(self._bundle, "{%s} %s {%s}" % (self.uniquetwig, symbol, other.uniquetwig), default_unit=default_unit)
             elif isinstance(other, u.Quantity):
-                #~ print "***", self.uniquetwig, "{%s} %s %f" % (self.uniquetwig, symbol, other.si.value)
-                return ConstraintParameter(self._bundle, "{%s} %s %0.30f" % (self.uniquetwig, symbol, other.si.value), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "{%s} %s %0.30f" % (self.uniquetwig, symbol, _value_for_constraint(other)), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, float) or isinstance(other, int):
                 if symbol in ['+', '-'] and hasattr(self, 'default_unit'):
                     # assume same units as self (NOTE: NOT NECESSARILY SI) if addition or subtraction
@@ -3487,7 +3498,7 @@ class Parameter(object):
                 else:
                     # assume dimensionless
                     other = float(other)*u.dimensionless_unscaled
-                return ConstraintParameter(self._bundle, "{%s} %s %f" % (self.uniquetwig, symbol, other.si.value), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "{%s} %s %f" % (self.uniquetwig, symbol, _value_for_constraint(other)), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, u.Unit) and mathfunc=='__mul__':
                 return self.quantity*other
             else:
@@ -3504,7 +3515,7 @@ class Parameter(object):
             elif isinstance(other, Parameter):
                 return ConstraintParameter(self._bundle, "{%s} %s {%s}" % (other.uniquetwig, symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other.quantity).unit))
             elif isinstance(other, u.Quantity):
-                return ConstraintParameter(self._bundle, "%0.30f %s {%s}" % (other.si.value, symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "%0.30f %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, float) or isinstance(other, int):
                 if symbol in ['+', '-'] and hasattr(self, 'default_unit'):
                     # assume same units as self if addition or subtraction
@@ -3512,7 +3523,7 @@ class Parameter(object):
                 else:
                     # assume dimensionless
                     other = float(other)*u.dimensionless_unscaled
-                return ConstraintParameter(self._bundle, "%f %s {%s}" % (other.si.value, symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "%f %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, u.Unit) and mathfunc=='__mul__':
                 return self.quantity*other
             else:
@@ -4533,9 +4544,6 @@ class FloatParameter(Parameter):
         return params
 
 
-#    def sin(self):
-#        return np.sin(self.get_value(unit=u.rad))
-
 class FloatArrayParameter(FloatParameter):
     def __init__(self, *args, **kwargs):
         """
@@ -5285,9 +5293,10 @@ class ConstraintParameter(Parameter):
         self._var_params = None
         self._constraint_func = kwargs.get('constraint_func', None)
         self._constraint_kwargs = kwargs.get('constraint_kwargs', {})
+        self._in_solar_units = kwargs.get('in_solar_units', False)
         self.set_value(value)
         self.set_default_unit(default_unit)
-        self._dict_fields_other = ['description', 'value', 'default_unit', 'constraint_func', 'constraint_kwargs']
+        self._dict_fields_other = ['description', 'value', 'default_unit', 'constraint_func', 'constraint_kwargs', 'in_solar_units']
         self._dict_fields = _meta_fields_all + self._dict_fields_other
 
     @property
@@ -5305,6 +5314,12 @@ class ConstraintParameter(Parameter):
         """
         """
         return self._constraint_kwargs
+
+    @property
+    def in_solar_units(self):
+        """
+        """
+        return self._in_solar_units
 
     @property
     def vars(self):
@@ -5484,14 +5499,15 @@ class ConstraintParameter(Parameter):
         return expr
 
     def __repr__(self):
+        expr = "{} ({})".format(self.expr, "solar units" if self.in_solar_units else "SI")
         if self.qualifier is not None:
             lhs = '{'+self.get_constrained_parameter().uniquetwig+'}'
-            return "<ConstraintParameter: {} = {} => {}>".format(lhs, self.expr, self.result)
+            return "<ConstraintParameter: {} = {} => {}>".format(lhs, expr, self.result)
         else:
-            return "<ConstraintParameter: {} => {}>".format(self.expr, self.result)
+            return "<ConstraintParameter: {} => {}>".format(expr, self.result)
 
     def __str__(self):
-        return "Constrains (qualifier): {}\nExpression in SI (value): {}\nCurrent Result (result): {}".format(self.qualifier, self.expr, self.result)
+        return "Constrains (qualifier): {}\nExpression in {} (value): {}\nCurrent Result (result): {}".format(self.qualifier, 'solar units' if self.in_solar_units else 'SI', self.expr, self.result)
 
     def __math__(self, other, symbol, mathfunc):
         #~ print "*** ConstraintParameter.__math__ other.type", type(other)
@@ -5502,7 +5518,7 @@ class ConstraintParameter(Parameter):
             return ConstraintParameter(self._bundle, "(%s) %s {%s}" % (self.expr, symbol, other.uniquetwig), default_unit=(getattr(self.result, mathfunc)(other.quantity).unit))
         elif isinstance(other, u.Quantity):
             #print "***", other, type(other), isinstance(other, ConstraintParameter)
-            return ConstraintParameter(self._bundle, "(%s) %s %0.30f" % (self.expr, symbol, other.si.value), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "(%s) %s %0.30f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, float) or isinstance(other, int):
             if symbol in ['+', '-']:
                 # assume same units as self (NOTE: NOT NECESSARILY SI) if addition or subtraction
@@ -5510,7 +5526,7 @@ class ConstraintParameter(Parameter):
             else:
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
-            return ConstraintParameter(self._bundle, "(%s) %s %f" % (self.expr, symbol, other.si.value), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "(%s) %s %f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif _is_unit(other) and mathfunc=='__mul__':
             # here we'll fake the unit to become a quantity so that we still return a ConstraintParameter
             return self*(1*other)
@@ -5526,7 +5542,7 @@ class ConstraintParameter(Parameter):
             return ConstraintParameter(self._bundle, "{%s} %s (%s)" % (other.uniquetwig, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other.quantity).unit))
         elif isinstance(other, u.Quantity):
             #~ print "*** rmath", other, type(other)
-            return ConstraintParameter(self._bundle, "%0.30f %s (%s)" % (other.si.value, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "%0.30f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, float) or isinstance(other, int):
             if symbol in ['+', '-']:
                 # assume same units as self if addition or subtraction
@@ -5534,7 +5550,7 @@ class ConstraintParameter(Parameter):
             else:
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
-            return ConstraintParameter(self._bundle, "%f %s (%s)" % (other.si.value, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "%f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif _is_unit(other) and mathfunc=='__mul__':
             # here we'll fake the unit to become a quantity so that we still return a ConstraintParameter
             return self*(1*other)
@@ -5599,9 +5615,15 @@ class ConstraintParameter(Parameter):
             return False
 
         def get_values(vars, safe_label=True):
-            # use np.float64 so that dividing by zero will results in a
+            # use np.float64 so that dividing by zero will result in a
             # np.inf
-            return {var.safe_label if safe_label else var.user_label: np.float64(var.get_quantity(t=t).si.value) if var.get_parameter()!=self.constrained_parameter else np.float64(var.get_quantity().si.value) for var in vars}
+            def _single_value(quantity):
+                if self.in_solar_units:
+                    return np.float64(u.to_solar(quantity).value)
+                else:
+                    return np.float64(quantity.si.value)
+
+            return {var.safe_label if safe_label else var.user_label: _single_value(var.get_quantity(t=t)) if var.get_parameter()!=self.constrained_parameter else _single_value(var.get_quantity()) for var in vars}
 
         eq = self.get_value()
 
@@ -5674,7 +5696,10 @@ class ConstraintParameter(Parameter):
         # let's assume the math was correct to give SI and we want units stored in self.default_units
 
         if self.default_unit is not None:
-            convert_scale = self.default_unit.to_system(u.si)[0].scale
+            if self.in_solar_units:
+                convert_scale = u.to_solar(self.default_unit)
+            else:
+                convert_scale = self.default_unit.to_system(u.si)[0].scale
             #value = float(value/convert_scale) * self.default_unit
             value = value/convert_scale * self.default_unit
 

--- a/setup.py
+++ b/setup.py
@@ -308,12 +308,12 @@ ext_modules = [
 # Main setup
 #
 setup (name = 'phoebe',
-       version = '2.1.1',
-       description = 'PHOEBE 2.1.1',
+       version = '2.1.2',
+       description = 'PHOEBE 2.1.2',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.1',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.2',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],

--- a/tests/nosetests/test_hierarchy/test_hierarchy.py
+++ b/tests/nosetests/test_hierarchy/test_hierarchy.py
@@ -1,0 +1,15 @@
+"""
+"""
+
+import phoebe
+
+def test_binary():
+    b = phoebe.Bundle.default_binary()
+
+    b.set_hierarchy()
+    return b
+
+if __name__ == '__main__':
+    logger = phoebe.logger(clevel='DEBUG')
+
+    b = test_binary()


### PR DESCRIPTION
* All constraints are now executed (by default) in solar units instead of SI.  The Kepler's third law constraint (constraining mass by default) failed to have sufficient precision in SI, resulting in inaccurate masses.  Furthermore, if the constraint was flipped, inaccurate values of sma could be passed to the backend, resulting in overflow in the semi-detached case.
* Bundles created before 2.1.2 and imported into 2.1.2+ will continue to use SI units for constraints and should function fine, but will not benefit from this update and will be incapable of changing the system hierarchy.