### PR TITLE
singlestar get_orbit and line-profile hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.1.5 - single star get_orbits and line-profile hotfix
+
+* Fixes a bug in hierarchy.get_orbits() for a single star hierarchy which resulted in an error being raised while computing line-profiles.
+
 ### 2.1.4 - freq constraint hotfix
 
 * This fixes the inversion of the frequency constraint when flipping to solve for period.
@@ -70,7 +74,7 @@ CHANGELOG
 
 * Semi-detached systems could raise an error in the backend caused by the volume being slightly over the critical value when translating between requiv in solar units to volume in unitless/roche units.  When this numerical discrepancy is detected, the critical value is now adopted and a warning is sent via the logger.
 
-### 2.1.2 - Constraints in solar units hotfix
+### 2.1.2 - constraints in solar units hotfix
 
 * All constraints are now executed (by default) in solar units instead of SI.  The Kepler's third law constraint (constraining mass by default) failed to have sufficient precision in SI, resulting in inaccurate masses.  Furthermore, if the constraint was flipped, inaccurate values of sma could be passed to the backend, resulting in overflow in the semi-detached case.
 * Bundles created before 2.1.2 and imported into 2.1.2+ will continue to use SI units for constraints and should function fine, but will not benefit from this update and will be incapable of changing the system hierarchy.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -10,7 +10,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.1.4'
+__version__ = '2.1.5'
 
 import os
 import sys as _sys

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -5025,7 +5025,7 @@ class HierarchyParameter(StringParameter):
         orbits = []
         for star in self.get_stars():
             parent = self.get_parent_of(star)
-            if parent not in orbits and parent!='component':
+            if parent not in orbits and parent!='component' and parent is not None:
                 orbits.append(parent)
         return orbits
 

--- a/setup.py
+++ b/setup.py
@@ -308,12 +308,12 @@ ext_modules = [
 # Main setup
 #
 setup (name = 'phoebe',
-       version = '2.1.4',
-       description = 'PHOEBE 2.1.4',
+       version = '2.1.5',
+       description = 'PHOEBE 2.1.5',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.4',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.5',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
Fixes a bug in hierarchy.get_orbits() for a single star hierarchy which resulted in an error being raised while computing line-profiles.