### PR TITLE
comparison operators hotfix (2.1.7 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.1.7 - comparison operators hotfix
+
+* Fixes a bug where comparisons between Parameters/ParameterSets and values were returning nonsensical values.
+* Comparing ParameterSets with any object will now return a NotImplementedError
+* Comparing Parameters will compare against the value or quantity, with default units when applicable.
+* Comparing equivalence between two Parameter objects will compare the uniqueids of the Parameters, NOT the values.
+
 ### 2.1.6 - optimization hotfix
 
 * Fixes a bug where automatic detection of eclipses was failing to properly fallback on only detecting the horizon.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -10,7 +10,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.1.6'
+__version__ = '2.1.7'
 
 import os
 import sys as _sys

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -361,6 +361,25 @@ class ParameterSet(object):
 
         return "ParameterSet: {} parameters\n".format(len(self._params))+param_info
 
+    def __lt__(self, other):
+        raise NotImplementedError("comparison operators with ParameterSets are not supported")
+
+    def __le__(self, other):
+        raise NotImplementedError("comparison operators with ParameterSets are not supported")
+
+    def __gt__(self, other):
+        raise NotImplementedError("comparison operators with ParameterSets are not supported")
+
+    def __ge__(self, other):
+        raise NotImplementedError("comparison operators with ParameterSets are not supported")
+
+    def __eq__(self, other):
+        raise NotImplementedError("comparison operators with ParameterSets are not supported")
+
+    def __ne__(self, other):
+        raise NotImplementedError("comparison operators with ParameterSets are not supported")
+
+
     @property
     def meta(self):
         """Dictionary of all meta-tags.
@@ -1649,7 +1668,7 @@ class ParameterSet(object):
         """
         # TODO: check to see if protected (required by a current constraint or
         # by a backend)
-        self._params = [p for p in self._params if p != param]
+        self._params = [p for p in self._params if p.uniqueid != param.uniqueid]
 
     def remove_parameter(self, twig=None, **kwargs):
         """
@@ -2963,13 +2982,44 @@ class Parameter(object):
         """
         return 1
 
+    def __comp__(self, other, comp):
+        if isinstance(other, float) or isinstance(other, int):
+            return getattr(self.get_value(), comp)(other)
+        elif isinstance(other, u.Quantity):
+            return getattr(self.get_quantity(), comp)(other)
+        elif isinstance(other, str) and isinstance(self.get_value(), str) and comp in ['__eq__', '__ne__']:
+            return getattr(self.get_value(), comp)(other)
+        elif isinstance(other, tuple) and len(other)==2 and (isinstance(other[0], float) or isinstance(other[0], int)) and isinstance(other[1], str):
+            return self.__comp__(other[0]*u.Unit(other[1]), comp)
+        else:
+            raise NotImplementedError("cannot compare between {} and {}".format(self.__class__.__name__, type(other)))
+
+
+    def __lt__(self, other):
+        return self.__comp__(other, '__lt__')
+
+    def __le__(self, other):
+        return self.__comp__(other, '__le__')
+
+    def __gt__(self, other):
+        return self.__comp__(other, '__gt__')
+
+    def __ge__(self, other):
+        return self.__comp__(other, '__ge__')
+
     def __eq__(self, other):
         """
         """
-        # TODO: check value as well
-        if not isinstance(other, Parameter):
+        if other is None:
             return False
+
+        if not isinstance(other, Parameter):
+            return self.__comp__(other, '__eq__')
+
         return self.uniqueid == other.uniqueid
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def copy(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -308,12 +308,12 @@ ext_modules = [
 # Main setup
 #
 setup (name = 'phoebe',
-       version = '2.1.6',
-       description = 'PHOEBE 2.1.6',
+       version = '2.1.7',
+       description = 'PHOEBE 2.1.7',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.6',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.7',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
* Fixes a bug where comparisons between Parameters/ParameterSets and values were returning nonsensical values.
* Comparing ParameterSets with any object will now return a NotImplementedError
* Comparing Parameters will compare against the value or quantity, with default units when applicable.
* Comparing equivalence between two Parameter objects will compare the uniqueids of the Parameters, NOT the values.