### PR TITLE
ldint hotfix (2.1.10 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.1.10 - ldint hotfix
+
+* Removes ldint from the weights in the computations of RVs and LPs.
+
 ### 2.1.9 - limits hotfix
 
 * Fixes a bug where parameter limits were not being checked and out-of-limits errors not raised correctly.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -10,7 +10,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.1.9'
+__version__ = '2.1.10'
 
 import os
 import sys as _sys

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -588,7 +588,6 @@ class System(object):
             # be weighted by the visibility of the triangle
             mus = meshes.get_column_flat('mus', components)
             areas = meshes.get_column_flat('areas_si', components)
-            ldint = meshes.get_column_flat('ldint:{}'.format(dataset), components)
 
             rvs = (meshes.get_column_flat("rvs:{}".format(dataset), components)*u.solRad/u.d).to(u.m/u.s).value
             dls = rvs*profile_rest/c.c.si.value
@@ -598,7 +597,7 @@ class System(object):
             if not np.any(visibilities):
                 avg_line = np.full_like(wavelengths, np.nan)
             else:
-                avg_line = np.average(lines, axis=0, weights=abs_intensities*areas*mus*ldint*visibilities)
+                avg_line = np.average(lines, axis=0, weights=abs_intensities*areas*mus*visibilities)
 
             return {'flux_densities': avg_line}
 
@@ -616,13 +615,12 @@ class System(object):
             # be weighted by the visibility of the triangle
             mus = meshes.get_column_flat('mus', components)
             areas = meshes.get_column_flat('areas_si', components)
-            ldint = meshes.get_column_flat('ldint:{}'.format(dataset), components)
             # NOTE: don't need ptfarea because its a float (same for all
             # elements, regardless of component)
 
             # NOTE: the intensities are already projected but are per unit area
             # so we need to multiply by the /projected/ area of each triangle (thus the extra mu)
-            return {'rv': np.average(rvs, weights=abs_intensities*areas*mus*ldint*visibilities)}
+            return {'rv': np.average(rvs, weights=abs_intensities*areas*mus*visibilities)}
 
         elif kind=='lc':
             visibilities = meshes.get_column_flat('visibilities')
@@ -635,7 +633,6 @@ class System(object):
             intensities = meshes.get_column_flat("intensities:{}".format(dataset), components)
             mus = meshes.get_column_flat('mus', components)
             areas = meshes.get_column_flat('areas_si', components)
-            ldint = meshes.get_column_flat('ldint:{}'.format(dataset), components)
 
             # assume that all bodies are using the same passband and therefore
             # will have the same ptfarea.  If this assumption is ever a problem -
@@ -649,15 +646,15 @@ class System(object):
             else:
                 ptfarea = self.bodies[0].get_ptfarea(dataset)
 
-            # intens_proj is the intensity in the direction of the observer per unit surface area of the triangle
-            # areas is the area of each triangle
+            # intensities (Imu) is the intensity in the direction of the observer per unit surface area of the triangle, scaled according to pblum scaling
+            # areas is the area of each triangle (using areas_si from the mesh to force SI units)
             # areas*mus is the area of each triangle projected in the direction of the observer
             # visibilities is 0 for hidden, 0.5 for partial, 1.0 for visible
             # areas*mus*visibilities is the visibile projected area of each triangle (ie half the area for a partially-visible triangle)
-            # so, intens_proj*areas*mus*visibilities is the intensity in the direction of the observer per the observed projected area of that triangle
+            # so, intensities*areas*mus*visibilities is the intensity in the direction of the observer per the observed projected area of that triangle
             # and the sum of these values is the observed flux
 
-            # note that the intensities are already projected but are per unit area
+            # note that the intensities are already projected (Imu) but are per unit area
             # so we need to multiply by the /projected/ area of each triangle (thus the extra mu)
 
             return {'flux': np.sum(intensities*areas*mus*visibilities)*ptfarea/(distance**2)+l3}

--- a/setup.py
+++ b/setup.py
@@ -308,12 +308,12 @@ ext_modules = [
 # Main setup
 #
 setup (name = 'phoebe',
-       version = '2.1.9',
-       description = 'PHOEBE 2.1.9',
+       version = '2.1.10',
+       description = 'PHOEBE 2.1.10',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.9',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.10',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
* Removes ldint from the weights in the computations of RVs and LPs.