### PR TITLE
allow for negative ld coefficients

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -2285,7 +2285,7 @@ class Bundle(ParameterSet):
                                     True)
 
 
-                check = libphoebe.ld_check(_bytes(ld_func), np.asarray(ld_coeffs))
+                check = libphoebe.ld_check(_bytes(ld_func), np.asarray(ld_coeffs), strict=False)
                 if not check:
                     report.add_item(self,
                                     'ld_coeffs_bol={} not compatible for ld_func_bol=\'{}\'.'.format(ld_coeffs, ld_func),
@@ -2293,6 +2293,17 @@ class Bundle(ParameterSet):
                                      self.get_parameter(qualifier='ld_coeffs_bol', component=component, context='component', **kwargs)
                                     ],
                                     True)
+
+                else:
+                    # only need to do the strict check if the non-strict checks passes
+                    check = libphoebe.ld_check(_bytes(ld_func), np.asarray(ld_coeffs), strict=True)
+                    if not check:
+                        report.add_item(self,
+                                        'ld_coeffs_bol={} result in limb-brightening.  Use with caution.'.format(ld_coeffs_bol),
+                                        [self.get_parameter(qualifier='ld_func_bol', component=component, context='component', **kwargs),
+                                         self.get_parameter(qualifier='ld_coeffs_bol', component=component, context='component', **kwargs)
+                                        ],
+                                        True)
 
             for compute in computes:
                 if self.get_compute(compute, **_skip_filter_checks).kind in ['legacy'] and ld_func not in ['linear', 'logarithmic', 'square_root']:
@@ -2362,7 +2373,7 @@ class Bundle(ParameterSet):
                                         ],
                                         True)
 
-                    check = libphoebe.ld_check(_bytes(ld_func), np.asarray(ld_coeffs))
+                    check = libphoebe.ld_check(_bytes(ld_func), np.asarray(ld_coeffs), strict=False)
                     if not check:
                         report.add_item(self,
                                         'ld_coeffs={} not compatible for ld_func=\'{}\'.'.format(ld_coeffs, ld_func),
@@ -2370,6 +2381,17 @@ class Bundle(ParameterSet):
                                          dataset_ps.get_parameter(qualifier='ld_coeffs', component=component, **kwargs)
                                         ],
                                         True)
+
+                    else:
+                        # only need to do the strict check if the non-strict checks passes
+                        check = libphoebe.ld_check(_bytes(ld_func), np.asarray(ld_coeffs), strict=True)
+                        if not check:
+                            report.add_item(self,
+                                            'ld_coeffs={} result in limb-brightening.  Use with caution.'.format(ld_coeffs),
+                                            [dataset_ps.get_parameter(qualifier='ld_func', component=component, **kwargs),
+                                             dataset_ps.get_parameter(qualifier='ld_coeffs', component=component, **kwargs)
+                                             ],
+                                             False)
 
                 else:
                     raise NotImplementedError("checks for ld_mode='{}' not implemented".format(ld_mode))

--- a/phoebe/lib/libphoebe.cpp
+++ b/phoebe/lib/libphoebe.cpp
@@ -9546,7 +9546,7 @@ static PyObject *ld_check(PyObject *self, PyObject *args, PyObject *keywds) {
 
   PyArrayObject *o_params;
 
-  if (!PyArg_ParseTupleAndKeywords(args, keywds,  "O!O!O!", kwlist,
+  if (!PyArg_ParseTupleAndKeywords(args, keywds,  "O!O!|O!", kwlist,
         &PyString_Type, &o_descr,
         &PyArray_Type,  &o_params,
         &PyBool_Type,   &o_strict )

--- a/phoebe/lib/libphoebe.cpp
+++ b/phoebe/lib/libphoebe.cpp
@@ -9482,7 +9482,7 @@ static PyObject *ld_nrpar(PyObject *self, PyObject *args, PyObject *keywds) {
 
   Python:
 
-    value = ld_check(descr, params)
+    value = ld_check(descr, params, strict=False)
 
   with arguments
 
@@ -9497,6 +9497,13 @@ static PyObject *ld_nrpar(PyObject *self, PyObject *args, PyObject *keywds) {
             "power"       4 parameters
 
     params: 1-rank numpy array of float
+
+  optional
+
+    strict: Boolean, default False
+
+    strict checking: if D(mu) in [0,1] for all mu in [0,1]
+    loose (non-strict): if D(mu) >=0 for all mu in [0,1]
 
   Return:
     true: if parameters pass the checks, false otherwise
@@ -9529,20 +9536,26 @@ static PyObject *ld_check(PyObject *self, PyObject *args, PyObject *keywds) {
   char *kwlist[] = {
     (char*)"descr",
     (char*)"params",
+    (char*)"strict",
     NULL
   };
 
-  PyObject *o_descr;
+  bool strict = false;
+
+  PyObject *o_descr, *o_strict = 0;
 
   PyArrayObject *o_params;
 
-  if (!PyArg_ParseTupleAndKeywords(args, keywds,  "O!O!", kwlist,
+  if (!PyArg_ParseTupleAndKeywords(args, keywds,  "O!O!O!", kwlist,
         &PyString_Type, &o_descr,
-        &PyArray_Type,  &o_params)
+        &PyArray_Type,  &o_params,
+        &PyBool_Type,   &o_strict )
       ){
     raise_exception(fname + "::Problem reading arguments");
     return NULL;
   }
+
+  if (o_strict) strict = PyBool_Check(o_strict);
 
   TLDmodel_type type = LD::type(PyString_AsString(o_descr));
 
@@ -9550,6 +9563,9 @@ static PyObject *ld_check(PyObject *self, PyObject *args, PyObject *keywds) {
     raise_exception(fname + "::This model is not supported");
     return NULL;
   }
+
+  if (strict)
+    return PyBool_FromLong(LD::check_strict(type, (double*)PyArray_DATA(o_params)));
 
   return PyBool_FromLong(LD::check(type, (double*)PyArray_DATA(o_params)));
 }


### PR DESCRIPTION
I've tested to make sure this builds and integrates into the checks successfully.

```
import phoebe

b = phoebe.default_binary()
b.add_dataset('lc')

b['ld_mode@primary'] = 'manual'
b['ld_coeffs@primary']  = [0.5, -0.5]

print(b.run_checks()) # PASSES

b['ld_coeffs@primary'] = [-0.5, 0.5]

print(b.run_checks()) # FAILS
```

@aprsa and/or @Raindogjones - can you please test to make sure this works as expected (and no longer requires hacks for "physical" cases to work) before I merge?

We should also consider whether this warrants a 2.1 bugfix or if rolling into 2.2 is sufficient.