### PR TITLE
Bugfix ignore fits passbands (2.1.17 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.1.17 - ignore fits passbands hotfix
+
+* Future-proof to ignore for passband files with extensions other than ".pb"
+  which may be introduced in future versions of PHOEBE.
+
 ### 2.1.16 - eccentric/misaligned irradiation hotfix
 
 * Fixes bug where irradiation was over-optimized and not recomputed as needed for

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -10,7 +10,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.1.16'
+__version__ = '2.1.17'
 
 import os
 import sys as _sys

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -179,7 +179,7 @@ class Passband:
         if not hasattr(self, 'version'):
             self.version = 1.0
         return('Passband: %s:%s\nVersion:  %1.1f\nProvides: %s' % (self.pbset, self.pbname, self.version, self.content))
-    
+
     def save(self, archive):
         struct = dict()
 
@@ -1143,17 +1143,15 @@ def init_passbands(refresh=False):
         # global passbands whenever there is a name conflict
         for path in [_pbdir_global, _pbdir_local]:
             for f in os.listdir(path):
-                if f=='README':
-                    continue
-                init_passband(path+f)
+                if f.split('.')[-1] == 'pb':
+                    init_passband(path+f)
 
         #Check if _pbdir_env has been set and load those passbands too
         if not _pbdir_env == None:
             for path in [_pbdir_env]:
                 for f in os.listdir(path):
-                    if f=='README':
-                        continue
-                    init_passband(path+f)
+                    if f.split('.')[-1] == 'pb':
+                        init_passband(path+f)
 
 
         _initialized = True

--- a/setup.py
+++ b/setup.py
@@ -308,12 +308,12 @@ ext_modules = [
 # Main setup
 #
 setup (name = 'phoebe',
-       version = '2.1.16',
-       description = 'PHOEBE 2.1.16',
+       version = '2.1.17',
+       description = 'PHOEBE 2.1.17',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.16',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.1.17',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
* Future-proof to ignore for passband files with extensions other than ".pb"
  which may be introduced in future versions of PHOEBE.