### PR TITLE
kwargs bugfix (2.2.2 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.2.2 - kwargs hotfix
+
+* fix overriding mesh_init_phi as kwarg to run_compute
+* fix pblum computation to not require irrad_method kwarg
+* fix bundle representation to exclude hidden parameters
+
 ### 2.2.1 - g++/gcc version check hotfix
 
 * Improves the detection of g++/gcc version to compare against requirements during setup.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ PHOEBE 2.2
   <a href="http://phoebe-project.org/docs"><img src="https://img.shields.io/badge/docs-passing-success.svg"/></a>
   <a href="https://ui.adsabs.harvard.edu/abs/2016ApJS..227...29P"><img src="https://img.shields.io/badge/ApJS-Prsa+2016-lightgrey.svg"/></a>
   <a href="https://ui.adsabs.harvard.edu/abs/2018ApJS..237...26H"><img src="https://img.shields.io/badge/ApJS-Horvat+2018-lightgrey.svg"/></a>
-  <a href="https://ui.adsabs.harvard.edu/abs/2019arXiv191209474J"><img src="https://img.shields.io/badge/arXiv-Jones+2020-lightgrey.svg"/></a>
+  <a href="https://ui.adsabs.harvard.edu/abs/2020ApJS..247...63J"><img src="https://img.shields.io/badge/ApJS-Jones+2020-lightgrey.svg"/></a>
 </p>
 
 <p align="center">
@@ -30,7 +30,7 @@ PHOEBE stands for PHysics Of Eclipsing BinariEs. PHOEBE is pronounced [fee-bee](
 
 PHOEBE 2 is a rewrite of the original PHOEBE code. For most up-to-date information please refer to the PHOEBE project webpage: [http://phoebe-project.org](http://phoebe-project.org)
 
-PHOEBE 2.0 is described by the release paper published in the Astrophysical Journal Supplement, [Prša et al. (2016, ApJS 227, 29)](https://ui.adsabs.harvard.edu/#abs/2016ApJS..227...29P).  The addition of support for misaligned stars in version 2.1 is described in [Horvat et al. (2018, ApJS 237, 26)](https://ui.adsabs.harvard.edu/#abs/2018ApJS..237...26H).  Interstellar extinction and support for Python 3 was added in version 2.2 and described in [Jones et al. (2020, submitted)](https://ui.adsabs.harvard.edu/abs/2019arXiv191209474J).
+PHOEBE 2.0 is described by the release paper published in the Astrophysical Journal Supplement, [Prša et al. (2016, ApJS 227, 29)](https://ui.adsabs.harvard.edu/#abs/2016ApJS..227...29P).  The addition of support for misaligned stars in version 2.1 is described in [Horvat et al. (2018, ApJS 237, 26)](https://ui.adsabs.harvard.edu/#abs/2018ApJS..237...26H).  Interstellar extinction and support for Python 3 was added in version 2.2 and described in [Jones et al. (2020, ApJS 247, 63)](https://ui.adsabs.harvard.edu/abs/2020ApJS..247...63J).
 
 PHOEBE 2 is released under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html).
 

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -14,7 +14,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.2.1'
+__version__ = '2.2.2'
 
 import os as _os
 import sys as _sys

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -2306,7 +2306,9 @@ class Star_roche(Star):
 
                     mesh_init_phi = np.random.random()*2*np.pi
                     logger.warning("mesh failed to converge, trying attempt #{} with mesh_init_phi={}".format(mesh_init_phi_attempts, mesh_init_phi))
-                    return self._build_mesh(mesh_method, mesh_init_phi=mesh_init_phi, mesh_init_phi_attempts=mesh_init_phi_attempts, **kwargs)
+                    kwargs['mesh_init_phi_attempts'] = mesh_init_phi_attempts
+                    kwargs['mesh_init_phi'] = mesh_init_phi
+                    return self._build_mesh(mesh_method, **kwargs)
                 else:
                     raise err
 
@@ -2511,7 +2513,9 @@ class Star_roche_envelope_half(Star):
 
                     mesh_init_phi = np.random.random()*2*np.pi
                     logger.warning("mesh failed to converge, trying attempt #{} with mesh_init_phi={}".format(mesh_init_phi_attempts, mesh_init_phi))
-                    return self._build_mesh(mesh_method, mesh_init_phi=mesh_init_phi, mesh_init_phi_attempts=mesh_init_phi_attempts, **kwargs)
+                    kwargs['mesh_init_phi_attempts'] = mesh_init_phi_attempts
+                    kwargs['mesh_init_phi'] = mesh_init_phi
+                    return self._build_mesh(mesh_method, **kwargs)
                 else:
                     raise err
 
@@ -2694,7 +2698,9 @@ class Star_rotstar(Star):
 
                     mesh_init_phi = np.random.random()*2*np.pi
                     logger.warning("mesh failed to converge, trying attempt #{} with mesh_init_phi={}".format(mesh_init_phi_attempts, mesh_init_phi))
-                    return self._build_mesh(mesh_method, mesh_init_phi=mesh_init_phi, mesh_init_phi_attempts=mesh_init_phi_attempts, **kwargs)
+                    kwargs['mesh_init_phi_attempts'] = mesh_init_phi_attempts
+                    kwargs['mesh_init_phi'] = mesh_init_phi
+                    return self._build_mesh(mesh_method, **kwargs)
                 else:
                     raise err
 
@@ -2859,7 +2865,9 @@ class Star_sphere(Star):
 
                     mesh_init_phi = np.random.random()*2*np.pi
                     logger.warning("mesh failed to converge, trying attempt #{} with mesh_init_phi={}".format(mesh_init_phi_attempts, mesh_init_phi))
-                    return self._build_mesh(mesh_method, mesh_init_phi=mesh_init_phi, mesh_init_phi_attempts=mesh_init_phi_attempts, **kwargs)
+                    kwargs['mesh_init_phi_attempts'] = mesh_init_phi_attempts
+                    kwargs['mesh_init_phi'] = mesh_init_phi
+                    return self._build_mesh(mesh_method, **kwargs)
                 else:
                     raise err
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -1385,10 +1385,12 @@ class Bundle(ParameterSet):
         self._last_client_update = datetime.now()
 
     def __repr__(self):
-        return super(Bundle, self).__repr__().replace('ParameterSet', 'PHOEBE Bundle')
+        # filter to handle any visibility checks, etc
+        return self.filter().__repr__().replace('ParameterSet', 'PHOEBE Bundle')
 
     def __str__(self):
-        return super(Bundle, self).__str__().replace('ParameterSet', 'PHOEBE Bundle')
+        # filter to handle any visibility checks, etc
+        return self.filter().__str__().replace('ParameterSet', 'PHOEBE Bundle')
 
     def _default_label(self, base, context, **kwargs):
         """

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -6454,7 +6454,7 @@ class Bundle(ParameterSet):
         _ = kwargs.pop('skip_checks', None)
         compute = computeparams.compute
 
-        if computeparams.kind == 'phoebe' and computeparams.get_value(qualifier='irrad_method', **_skip_filter_checks) !='none':
+        if computeparams.kind == 'phoebe':
             # then all we need to do is handle any ld_mode_bol=='lookup'
             self.compute_ld_coeffs(compute, dataset=['bol'], set_value=True, skip_checks=True)
             return

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -6458,7 +6458,8 @@ class Bundle(ParameterSet):
 
         if computeparams.kind == 'phoebe':
             # then all we need to do is handle any ld_mode_bol=='lookup'
-            self.compute_ld_coeffs(compute, dataset=['bol'], set_value=True, skip_checks=True)
+            if computeparams.get_value(qualifier='irrad_method', irrad_method=kwargs.get('irrad_method', None), default='none') != 'none':
+                self.compute_ld_coeffs(compute, dataset=['bol'], set_value=True, skip_checks=True)
             return
 
         enabled_datasets = computeparams.filter(qualifier='enabled', value=True).datasets

--- a/setup.py
+++ b/setup.py
@@ -322,12 +322,12 @@ def _env_variable_bool(key, default):
         return False
 
 setup (name = 'phoebe',
-       version = '2.2.1',
-       description = 'PHOEBE 2.2.1',
+       version = '2.2.2',
+       description = 'PHOEBE 2.2.2',
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
        url = 'http://github.com/phoebe-project/phoebe2',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.2.1',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.2.2',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.utils', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.10','scipy>=0.17','astropy>=1.0,<3.0' if sys.version_info[0] < 3 else 'astropy>=1.0', 'pytest'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
* fix overriding mesh_init_phi as kwarg to run_compute
* fix pblum computation to not require irrad_method kwarg
* fix bundle representation to exclude hidden parameters