### PR TITLE
Changing LooseVersion(). to LooseVersion().vstring

### DIFF
--- a/phoebe/solverbackends/solverbackends.py
+++ b/phoebe/solverbackends/solverbackends.py
@@ -1164,7 +1164,7 @@ class EmceeBackend(BaseSolverBackend):
         if not _use_emcee:
             raise ImportError("could not import emcee")
 
-        if LooseVersion(emcee.__version__) < LooseVersion("3.0.0"):
+        if LooseVersion(emcee.__version__).vstring < LooseVersion("3.0.0").vstring:
             raise ImportError("emcee backend requires emcee 3.0+, {} found".format(emcee.__version__))
 
         solver_ps = b.get_solver(solver=solver, **_skip_filter_checks)


### PR DESCRIPTION
In line 1167,

Changing `LooseVersion(emcee.__version__) < LooseVersion("3.0.0")` to `LooseVersion(emcee.__version__).vstring < LooseVersion("3.0.0").vstring` in order to solve a TypeError with `disutils.version` package.

If kept `LooseVersion(emcee.__version__) < LooseVersion("3.0.0")` then it raises `TypeError: '<' not supported between instances of 'str' and 'int'`
Although this error was observed in python3.8.2 but worked fine in python3.8.5.

The proposed change takes care of the data type of output given by `LooseVersion` and works fine with both python3.8.2 and python3.8.5.