### PR TITLE
rv_geometry with different lengths fix (2.3.16 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.3.16 - rv_geometry with different lengths fix
+
+* fixes estimator.rv_geometry when primary and secondary component have different times.
+
 ### 2.3.15 - alternate backends with l3_frac and dataset-scaled fix
 
 * fix bug in applying l3_frac within dataset scaling (pblum_mode='dataset-scaled') when using alternate backends.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -16,7 +16,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.3.15'
+__version__ = '2.3.16'
 
 import os as _os
 import sys as _sys

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-2.3.16"""
+"""
 Environment variables while manually building/installing:
 
 PHOEBE_SKIP_SCRIPTS=TRUE: will not install phoebe-server and phoebe-autofig executables (removing the following dependencies: flask, flask-cors, flask-socketio, gevent-websocket)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""
+2.3.16"""
 Environment variables while manually building/installing:
 
 PHOEBE_SKIP_SCRIPTS=TRUE: will not install phoebe-server and phoebe-autofig executables (removing the following dependencies: flask, flask-cors, flask-socketio, gevent-websocket)
@@ -346,8 +346,8 @@ else:
     long_description = "\n".join(long_description_s[long_description_s.index("INTRODUCTION"):])
 
 setup (name = 'phoebe',
-       version = '2.3.15',
-       description = 'PHOEBE 2.3.15',
+       version = '2.3.16',
+       description = 'PHOEBE 2.3.16',
        long_description=long_description,
        author = 'PHOEBE development team',
        author_email = 'phoebe-devel@lists.sourceforge.net',
@@ -367,7 +367,7 @@ setup (name = 'phoebe',
             'Programming Language :: Python :: 3 :: Only',
         ],
        python_requires='>=3.6, <4',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.3.15',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.3.16',
        packages = ['phoebe', 'phoebe.parameters', 'phoebe.parameters.solver', 'phoebe.parameters.figure', 'phoebe.frontend', 'phoebe.constraints', 'phoebe.dynamics', 'phoebe.distortions', 'phoebe.algorithms', 'phoebe.atmospheres', 'phoebe.backend', 'phoebe.solverbackends', 'phoebe.solverbackends.ebai', 'phoebe.utils', 'phoebe.helpers', 'phoebe.pool', 'phoebe.dependencies', 'phoebe.dependencies.autofig', 'phoebe.dependencies.nparray', 'phoebe.dependencies.distl', 'phoebe.dependencies.unitsiau2015'],
        install_requires=['numpy>=1.12','scipy>=1.2','astropy>=1.0', 'corner', 'pytest', 'requests', 'python-socketio[client]']+['flask', 'flask-cors', 'flask-socketio', 'gevent-websocket'],
        package_data={'phoebe.atmospheres':['tables/wd/*', 'tables/passbands/*'],


### PR DESCRIPTION
* fixes estimator.rv_geometry when primary and secondary component have different times.
* fixes #400 