### PR TITLE
gaussian_process backwards compatibility

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -5851,11 +5851,21 @@ class Bundle(ParameterSet):
         """
         return self.rename_feature(old_feature, new_feature, overwrite=overwrite, return_changes=return_changes)
 
-    def add_gp_sklearn(self, dataset=None, feature=None, **kwargs):
+    def add_gaussian_process(self, kind='sklearn', dataset=None, feature=None, **kwargs):
         """
-        Shortcut to <phoebe.frontend.bundle.Bundle.add_feature> but with kind='gp_sklearn'.
+        Shortcut to <phoebe.frontend.bundle.Bundle.add_feature> but with kind='gp_sklearn'
+        or kind='gp_celerite2'.
 
-        For details on the resulting parameters, see <phoebe.parameters.feature.gp_sklearn>.
+        For details on the resulting parameters, see <phoebe.parameters.feature.gp_sklearn>
+        or <phoebe.parameters.feature.gp_celerite2>.
+
+        Parameters
+        ----------
+        * `kind` (string, optional, default='sklearn'): sklearn or celerite2
+        * `dataset` (string, optional, default=None): dataset to attach the
+            gaussian process
+        * `feature` (string, optional, default=None): feature label to assign
+            to the gaussian process.
         """
         if dataset is None:
             if len(self.datasets)==1:
@@ -5865,27 +5875,11 @@ class Bundle(ParameterSet):
 
         kwargs.setdefault('dataset', dataset)
         kwargs.setdefault('feature', feature)
-        return self.add_feature('gp_sklearn', **kwargs)
-    
-    def add_gp_celerite2(self, dataset=None, feature=None, **kwargs):
-        """
-        Shortcut to <phoebe.frontend.bundle.Bundle.add_feature> but with kind='gp_celerite2'.
+        return self.add_feature(f"gp_{kind.strip('gp_')}", **kwargs)
 
-        For details on the resulting parameters, see <phoebe.parameters.feature.gp_celerite2>.
+    def get_gaussian_process(self, feature=None, **kwargs):
         """
-        if dataset is None:
-            if len(self.datasets)==1:
-                dataset = self.datasets[0]
-            else:
-                raise ValueError("must provide dataset for gaussian_process")
-
-        kwargs.setdefault('dataset', dataset)
-        kwargs.setdefault('feature', feature)
-        return self.add_feature('gp_celerite2', **kwargs)
-
-    def get_gp_sklearn(self, feature=None, **kwargs):
-        """
-        Shortcut to <phoebe.frontend.bundle.Bundle.get_feature> but with kind='gp_sklearn'.
+        Shortcut to <phoebe.frontend.bundle.Bundle.get_feature> but with kind='gp_*'.
 
         Arguments
         ----------
@@ -5895,33 +5889,12 @@ class Bundle(ParameterSet):
         Returns:
         * a <phoebe.parameters.ParameterSet> object.
         """
-        kwargs.setdefault('kind', 'gp_sklearn')
-        return self.get_feature(feature, **kwargs)
-    
-    def get_gp_celerite2(self, feature=None, **kwargs):
-        """
-        Shortcut to <phoebe.frontend.bundle.Bundle.get_feature> but with kind='gp_celerite2'.
-
-        Arguments
-        ----------
-        * `feature`: (string, optional, default=None): the name of the feature
-        * `**kwargs`: any other tags to do the filtering (excluding feature, kind, and context)
-
-        Returns:
-        * a <phoebe.parameters.ParameterSet> object.
-        """
-        kwargs.setdefault('kind', 'gp_celerite2')
+        kwargs.setdefault('kind', 'gp_*')
         return self.get_feature(feature, **kwargs)
 
-    def rename_gp_sklearn(self, old_feature, new_feature, overwrite=False, return_changes=False):
+    def rename_gaussian_process(self, old_feature, new_feature, overwrite=False, return_changes=False):
         """
-        Shortcut to <phoebe.frontend.bundle.Bundle.rename_feature> but with kind='gp_sklearn'.
-        """
-        return self.rename_feature(old_feature, new_feature, overwrite=overwrite, return_changes=return_changes)
-    
-    def rename_gp_celerite2(self, old_feature, new_feature, overwrite=False, return_changes=False):
-        """
-        Shortcut to <phoebe.frontend.bundle.Bundle.rename_feature> but with kind='gp_celerite2'.
+        Shortcut to <phoebe.frontend.bundle.Bundle.rename_feature>.
         """
         return self.rename_feature(old_feature, new_feature, overwrite=overwrite, return_changes=return_changes)
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -12027,7 +12027,7 @@ class Bundle(ParameterSet):
                     gp_celerite2_features = self.filter(feature=enabled_features, dataset=ds, kind='gp_celerite2', **_skip_filter_checks).features
                     
                     if len(gp_sklearn_features)!=0 and len(gp_celerite2_features)!=0:
-                        raise NotImplementedError('Combining GPs from scikit-learn and celerite2 is not supported yet. Please remove one with .remove_feature()')
+                        raise NotImplementedError('Combining GPs from scikit-learn and celerite2 is not supported yet. Please remove or disable one!')
                     
                     elif len(gp_sklearn_features)!=0 or len(gp_celerite2_features)!=0:
                         # we'll loop over components (for RVs or LPs, for example)

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -215,6 +215,10 @@ def lc(syn=False, as_ps=True, is_lc=True, **kwargs):
         params += [BoolParameter(qualifier='mask_enabled', value=kwargs.get('mask_enabled', True), description='Whether to apply the mask in mask_phases during plotting, calculate_residuals, calculate_chi2, calculate_lnlikelihood, and run_solver')]
         params += [FloatArrayParameter(visible_if='[component]mask_enabled:True', qualifier='mask_phases', component=kwargs.get('component_top', None), value=kwargs.get('mask_phases', []), default_unit=u.dimensionless_unscaled, required_shape=[None, 2], description='List of phase-tuples.  Any observations inside the range set by any of the tuples will be included.')]
 
+        # TODO: make these visible only if GPs attached
+        params += [BoolParameter(qualifier='exclude_phases_enabled', value=kwargs.get('mask_enabled', True), description='Whether to apply the mask in exclude_phases during Gaussian Process fitting.')]
+        params += [FloatArrayParameter(visible_if='[component]exclude_phases_enabled:True', qualifier='exclude_phases', component=kwargs.get('component_top', None), value=kwargs.get('exclude_phases', []), default_unit=u.dimensionless_unscaled, required_shape=[None, 2], description='List of phase-tuples.  Any observations inside the range set by any of the tuples will be ignored by the gaussian_process features.')]
+
         params += [ChoiceParameter(qualifier='solver_times', value=kwargs.get('solver_times', 'auto'), choices=['auto', 'compute_times', 'times'], description='times to use within run_solver.  All options will properly account for masking from mask_times.  To see how this is parsed, see b.parse_solver_times.  auto: use compute_times if provided and shorter than times, otherwise use times.  compute_times: use compute_times if provided.  times: use times array.')]
 
         params += [FloatArrayParameter(qualifier='sigmas', value=_empty_array(kwargs, 'sigmas'), required_shape=[None], default_unit=u.W/u.m**2, description='Observed uncertainty on flux')]

--- a/phoebe/parameters/feature.py
+++ b/phoebe/parameters/feature.py
@@ -5,6 +5,10 @@ from phoebe.parameters import constraint
 from phoebe import u
 from phoebe import conf
 
+import logging
+logger = logging.getLogger("FEATURE")
+logger.addHandler(logging.NullHandler())
+
 ### NOTE: if creating new parameters, add to the _forbidden_labels list in parameters.py
 
 def _component_allowed_for_feature(feature_kind, component_kind):
@@ -13,6 +17,7 @@ def _component_allowed_for_feature(feature_kind, component_kind):
     _allowed['pulsation'] = ['star', 'envelope']
     _allowed['gp_sklearn'] = [None]
     _allowed['gp_celerite2'] = [None]
+    _allowed['gaussian_process'] = [None]  # deprecated: remove in 2.5
 
     return component_kind in _allowed[feature_kind]
 
@@ -22,6 +27,7 @@ def _dataset_allowed_for_feature(feature_kind, dataset_kind):
     _allowed['pulsation'] = [None]
     _allowed['gp_sklearn'] = ['lc', 'rv', 'lp']
     _allowed['gp_celerite2'] = ['lc', 'rv', 'lp']
+    _allowed['gaussian_process'] = ['lc', 'rv', 'lp']  # deprecated: remove in 2.5
 
     return dataset_kind in _allowed[feature_kind]
 
@@ -119,8 +125,8 @@ def gp_sklearn(feature, **kwargs):
     * `periodicity` (float, optional, default=1.0): only applicable if `kernel` is 'exp_sine_sqaured'.
     * `sigma_0` (float, optional, default=1.0): only applicable if `kernel` is 'sigma_0'.
     * `alg_operation` (string, default='sum'): algebraic operation for the kernel with previously added ones.
-    * `exclude_phase_ranges` (list, optional, default=[]): list of start and end values defining phase ranges to 
-        exclude from modeling with GPs. 
+    * `exclude_phase_ranges` (list, optional, default=[]): list of start and end values defining phase ranges to
+        exclude from modeling with GPs.
 
     Returns
     --------
@@ -137,30 +143,30 @@ def gp_sklearn(feature, **kwargs):
     params += [FloatParameter(visible_if='kernel:white', qualifier='noise_level', value=kwargs.get('noise_level', 1.0), default_unit=u.dimensionless_unscaled, description='Noise level of the white kernel')]
     params += [FloatParameter(visible_if='kernel:rbf|rational_quadratic|exp_sine_squared|matern', qualifier='length_scale', value=kwargs.get('length_scale', 1.0), default_unit=u.dimensionless_unscaled, description='Length scale of the kernel')]
     params += [FloatParameter(visible_if='kernel:matern', qualifier='nu', value=kwargs.get('nu', 1.5), default_unit=u.dimensionless_unscaled, description='Smoothness factor of the Matern kernel')]
-    params += [FloatParameter(visible_if='kernel:rational_quadratic', qualifier='alpha', value=kwargs.get('alpha', 1.0), default_unit=u.dimensionless_unscaled, description='Scale mixture parameter of the RationalQuadratic kernel')]    
+    params += [FloatParameter(visible_if='kernel:rational_quadratic', qualifier='alpha', value=kwargs.get('alpha', 1.0), default_unit=u.dimensionless_unscaled, description='Scale mixture parameter of the RationalQuadratic kernel')]
     params += [FloatParameter(visible_if='kernel:exp_sine_squared', qualifier='periodicity', value=kwargs.get('periodicity', 1.0), default_unit=u.dimensionless_unscaled, description='Periodicity parameter of the ExpSineSquared kernel')]
-    params += [FloatParameter(visible_if='kernel:dot_product', qualifier='sigma_0', value=kwargs.get('sigma_0', 1.0), default_unit=u.dimensionless_unscaled, description='Constant factor of the DotProduct kernel')]    
-    
+    params += [FloatParameter(visible_if='kernel:dot_product', qualifier='sigma_0', value=kwargs.get('sigma_0', 1.0), default_unit=u.dimensionless_unscaled, description='Constant factor of the DotProduct kernel')]
+
     params += [StringParameter(visible_if='kernel:constant', qualifier='constant_value_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Value bounds of the constant kernel')]
     params += [StringParameter(visible_if='kernel:white', qualifier='noise_level_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Noise level bounds of the white kernel')]
     params += [StringParameter(visible_if='kernel:rbf|rational_quadratic|exp_sine_squared|matern', qualifier='length_scale_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Length scale bounds of the kernel')]
     params += [StringParameter(visible_if='kernel:matern', qualifier='nu_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Smoothness factor bounds of the Matern kernel')]
-    params += [StringParameter(visible_if='kernel:rational_quadratic', qualifier='alpha_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Scale mixture parameter bounds of the RationalQuadratic kernel')]    
+    params += [StringParameter(visible_if='kernel:rational_quadratic', qualifier='alpha_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Scale mixture parameter bounds of the RationalQuadratic kernel')]
     params += [StringParameter(visible_if='kernel:exp_sine_squared', qualifier='periodicity_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Periodicity parameter bounds of the ExpSineSquared kernel')]
-    params += [StringParameter(visible_if='kernel:dot_product', qualifier='sigma_0_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Constant factor bounds of the DotProduct kernel')]   
+    params += [StringParameter(visible_if='kernel:dot_product', qualifier='sigma_0_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Constant factor bounds of the DotProduct kernel')]
 
     # additional parameters for GPs
-    params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')] 
-    params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')] 
+    params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')]
+    params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')]
     constraints = []
 
     return ParameterSet(params), constraints
 
 def gp_celerite2(feature, **kwargs):
     """
-    Create a <phoebe.parameters.ParameterSet> for a gaussian_process feature.
+    Create a <phoebe.parameters.ParameterSet> for a gp_celerite2 feature.
 
-    Requires celerite to be installed.  See https://celerite2.readthedocs.io/en/stable/.
+    Requires celerite2 to be installed.  See https://celerite2.readthedocs.io/en/stable/.
     If using gaussian processes, consider citing:
     * https://ui.adsabs.harvard.edu/abs/2017AJ....154..220F
 
@@ -200,18 +206,18 @@ def gp_celerite2(feature, **kwargs):
         'sho'.
     * `sigma` (float, optional, default=1.0)
     * `period` (float, optional, default=1.0): only applicable if `kernel` is
-        'rotation'. 
+        'rotation'.
     * `Q0` (float, optional, default=1.0): only applicable if `kernel` is
-        'rotation'. 
+        'rotation'.
     * `dQ` (float, optional, default=1.0): only applicable if `kernel` is
-        'rotation'. 
+        'rotation'.
     * `f` (float, optional, default=1.0): only applicable if `kernel` is
-        'rotation'. 
+        'rotation'.
     * `eps` (float, optional, default=1e-5): only applicable if `kernel` is
-        'sho' or 'matern32'. 
+        'sho' or 'matern32'.
     * `alg_operation` (string, default='sum'): algebraic operation for the kernel with previously added ones.
-    * `exclude_phase_ranges` (list, optional, default=[]): list of start and end values defining phase ranges to 
-        exclude from modeling with GPs. 
+    * `exclude_phase_ranges` (list, optional, default=[]): list of start and end values defining phase ranges to
+        exclude from modeling with GPs.
 
     Returns
     --------
@@ -233,115 +239,21 @@ def gp_celerite2(feature, **kwargs):
     params += [FloatParameter(visible_if='kernel:rotation', qualifier='Q0', value=kwargs.get('Q0', 1.0), default_unit = u.dimensionless_unscaled, description='The quality factor for the secondary oscillation.')]
     params += [FloatParameter(visible_if='kernel:rotation', qualifier='dQ', value=kwargs.get('dQ', 1.0), default_unit = u.dimensionless_unscaled, description='The difference between the quality factors of the first and the second modes.')]
     params += [FloatParameter(visible_if='kernel:rotation', qualifier='f', value=kwargs.get('f', 1.0), default_unit = u.dimensionless_unscaled, description='The fractional amplitude of the secondary mode compared to the primary.')]
-    params += [FloatParameter(visible_if='kernel:sho|matern32', qualifier='eps', value=kwargs.get('eps', 1e-5), default_unit = u.dimensionless_unscaled, description='A regularization parameter used for numerical stability.')] 
-    
+    params += [FloatParameter(visible_if='kernel:sho|matern32', qualifier='eps', value=kwargs.get('eps', 1e-5), default_unit = u.dimensionless_unscaled, description='A regularization parameter used for numerical stability.')]
+
     # additional parameters for GPs
-    params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')] 
-    params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')] 
+    params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')]
+    params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')]
     constraints = []
 
     return ParameterSet(params), constraints
-  
-# def gaussian_process(feature, **kwargs):
-#     """
-#     Create a <phoebe.parameters.ParameterSet> for a gaussian_process feature.
 
-#     Requires celerite to be installed.  See https://celerite.readthedocs.io/en/stable/.
-#     If using gaussian processes, consider citing:
-#     * https://ui.adsabs.harvard.edu/abs/2017AJ....154..220F
+def gaussian_process(feature, **kwargs):
+    """
+    Deprecated (will be removed in PHOEBE 2.5)
 
-#     See also:
-#     * <phoebe.frontend.bundle.Bundle.references>
-
-#     Generally, this will be used as an input to the kind argument in
-#     <phoebe.frontend.bundle.Bundle.add_feature>.  If attaching through
-#     <phoebe.frontend.bundle.Bundle.add_feature>, all `**kwargs` will be
-#     passed on to set the values as described in the arguments below.  Alternatively,
-#     see <phoebe.parameters.ParameterSet.set_value> to set/change the values
-#     after creating the Parameters.
-
-#     Allowed to attach to:
-#     * components: not allowed
-#     * datasets with kind: lc
-
-#     If `compute_times` or `compute_phases` is used: the underlying model without
-#     gaussian_processes will be computed at the given times/phases but will then
-#     be interpolated into the times of the underlying dataset to include the
-#     contribution of gaussian processes and will be exposed at the dataset
-#     times (with a warning in the logger and in
-#     <phoebe.frontend.bundle.Bundle.run_checks_compute>).  If the system is
-#     time-dependent without GPs
-#     (see <phoebe.parameters.HierarchyParameter.is_time_dependent>), then
-#     the underlying model will need to cover the entire dataset or an error
-#     will be raised by <phoebe.frontend.bundle.Bundle.run_checks_compute>.
-
-
-#     Arguments
-#     ----------
-#     * `kernel` (string, optional, default='matern32'): Kernel for the gaussian
-#         process (see https://celerite.readthedocs.io/en/stable/python/kernel/)
-#     * `log_S0` (float, optional, default=0): only applicable if `kernel` is
-#         'sho'. Log of the GP parameter S0.
-#     * `log_Q` (float, optional, default=0): only applicable if `kernel` is
-#         'sho'.  Log of the GP parameter Q.
-#     * `log_omega0` (float, optional, default=0): only applicable if `kernel` is
-#         'sho'.  Log of the GP parameter omega0.
-#     * `log_sigma` (float, optional, default=0): only applicable if `kernel` is
-#         'matern32'.  Log of the GP parameter sigma.
-#     * `log_rho` (float, optional, default=0): only applicable if `kernel` is
-#         'matern32'.  Log of the GP parameter rho.
-#     * `eps` (float, optional, default=0): only applicable if `kernel` is
-#         'matern32'.  Log of the GP parameter epsilon.
-
-
-#     Returns
-#     --------
-#     * (<phoebe.parameters.ParameterSet>, list): ParameterSet of all newly created
-#         <phoebe.parameters.Parameter> objects and a list of all necessary
-#         constraints.
-#     """
-
-#     params = []
-
-#     params += [ChoiceParameter(qualifier='kernel', value=kwargs.get('kernel', 'white'), choices=['constant', 'white', 'rbf', 'matern', 'rational_quadratic', 'exp_sine_squared', 'dot_product', 'sho', 'rotation', 'matern32'], description='Kernel for the gaussian process (see https://scikit-learn.org/stable/modules/gaussian_process.html)')]
-
-#     # sklearn kernel parameters
-#     params += [FloatParameter(visible_if='kernel:constant', qualifier='constant_value', value=kwargs.get('constant_value', 1.0), default_unit=u.dimensionless_unscaled, description='Value of the constant kernel')]
-#     params += [FloatParameter(visible_if='kernel:white', qualifier='noise_level', value=kwargs.get('noise_level', 1.0), default_unit=u.dimensionless_unscaled, description='Noise level of the white kernel')]
-#     params += [FloatParameter(visible_if='kernel:rbf|rational_quadratic|exp_sine_squared|matern', qualifier='length_scale', value=kwargs.get('length_scale', 1.0), default_unit=u.dimensionless_unscaled, description='Length scale of the kernel')]
-#     params += [FloatParameter(visible_if='kernel:matern', qualifier='nu', value=kwargs.get('nu', 1.5), default_unit=u.dimensionless_unscaled, description='Smoothness factor of the Matern kernel')]
-#     params += [FloatParameter(visible_if='kernel:rational_quadratic', qualifier='alpha', value=kwargs.get('alpha', 1.0), default_unit=u.dimensionless_unscaled, description='Scale mixture parameter of the RationalQuadratic kernel')]    
-#     params += [FloatParameter(visible_if='kernel:exp_sine_squared', qualifier='periodicity', value=kwargs.get('periodicity', 1.0), default_unit=u.dimensionless_unscaled, description='Periodicity parameter of the ExpSineSquared kernel')]
-#     params += [FloatParameter(visible_if='kernel:dot_product', qualifier='sigma_0', value=kwargs.get('sigma_0', 1.0), default_unit=u.dimensionless_unscaled, description='Constant factor of the DotProduct kernel')]    
-    
-#     params += [StringParameter(visible_if='kernel:constant', qualifier='constant_value_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Value bounds of the constant kernel')]
-#     params += [StringParameter(visible_if='kernel:white', qualifier='noise_level_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Noise level bounds of the white kernel')]
-#     params += [StringParameter(visible_if='kernel:rbf|rational_quadratic|exp_sine_squared|matern', qualifier='length_scale_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Length scale bounds of the kernel')]
-#     params += [StringParameter(visible_if='kernel:matern', qualifier='nu_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Smoothness factor bounds of the Matern kernel')]
-#     params += [StringParameter(visible_if='kernel:rational_quadratic', qualifier='alpha_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Scale mixture parameter bounds of the RationalQuadratic kernel')]    
-#     params += [StringParameter(visible_if='kernel:exp_sine_squared', qualifier='periodicity_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Periodicity parameter bounds of the ExpSineSquared kernel')]
-#     params += [StringParameter(visible_if='kernel:dot_product', qualifier='sigma_0_bounds', value='fixed', default_unit=u.dimensionless_unscaled, description='Constant factor bounds of the DotProduct kernel')]   
-
-#     # celerite2 kernel parameters
-#     params += [FloatParameter(visible_if='kernel:sho|matern32', qualifier='rho', value=kwargs.get('rho', 1.0), default_unit = u.dimensionless_unscaled, description='Periodicity of the SHO kernel.')]
-#     params += [FloatParameter(visible_if='kernel:sho', qualifier='tau', value=kwargs.get('tau', 1.0), default_unit = u.dimensionless_unscaled, description='Damping timescale of the SHO kernel.')]
-#     params += [FloatParameter(visible_if='kernel:sho|rotation|matern32', qualifier='sigma', value=kwargs.get('sigma', 1.0), default_unit = u.dimensionless_unscaled, description='Standard deviation of the process.')]
-#     params += [FloatParameter(visible_if='kernel:rotation', qualifier='period', value=kwargs.get('period', 1.0), default_unit = u.dimensionless_unscaled, description='The primary period of variability of the rotation kernel.')]
-#     params += [FloatParameter(visible_if='kernel:rotation', qualifier='Q0', value=kwargs.get('Q0', 1.0), default_unit = u.dimensionless_unscaled, description='The quality factor for the secondary oscillation.')]
-#     params += [FloatParameter(visible_if='kernel:rotation', qualifier='dQ', value=kwargs.get('dQ', 1.0), default_unit = u.dimensionless_unscaled, description='The difference between the quality factors of the first and the second modes.')]
-#     params += [FloatParameter(visible_if='kernel:rotation', qualifier='f', value=kwargs.get('f', 1.0), default_unit = u.dimensionless_unscaled, description='The fractional amplitude of the secondary mode compared to the primary.')]
-#     params += [FloatParameter(visible_if='kernel:sho|matern32', qualifier='eps', value=kwargs.get('eps', 1e-5), default_unit = u.dimensionless_unscaled, description='A regularization parameter used for numerical stability.')] 
-    
-#     # additional parameters for GPs
-#     params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')] 
-#     params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')] 
-#     constraints = []
-
-#     return ParameterSet(params), constraints
-
-
-
-# # del deepcopy
-# # del _component_allowed_for_feature
-# # del download_passband, list_installed_passbands, list_online_passbands, list_passbands, parameter_from_json, parse_json, send_if_client, update_if_client
-# # del fnmatch
+    Support for celerite gaussian processes has been removed.  This is now an
+    alias to <phoebe.parameters.feature.gp_celerite2>.
+    """
+    logger.warning("gaussian_process is deprecated.  Use gp_celerite2 instead.")
+    return gp_celerite2(feature, **kwargs)

--- a/phoebe/parameters/feature.py
+++ b/phoebe/parameters/feature.py
@@ -157,7 +157,7 @@ def gp_sklearn(feature, **kwargs):
 
     # additional parameters for GPs
     params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')]
-    params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')]
+    # params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')]
     constraints = []
 
     return ParameterSet(params), constraints
@@ -243,7 +243,7 @@ def gp_celerite2(feature, **kwargs):
 
     # additional parameters for GPs
     params += [ChoiceParameter(qualifier='alg_operation', value='sum', choices=['sum', 'product'], default_unit=u.dimensionless_unscaled, description='Algebraic operation of this kernel with previous ones. Can be one of [sum, product]')]
-    params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')]
+    # params += [FloatArrayParameter(qualifier='exclude_phase_ranges', value=kwargs.get('exclude_phase_ranges', []), required_shape=[None, 2], default_unit=u.dimensionless_unscaled, description='Phase ranges to exclude from fitting the GP model (typically correspond to ingress and egress of eclipses).')]
     constraints = []
 
     return ParameterSet(params), constraints

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -215,6 +215,7 @@ _forbidden_labels += ['requiv', 'requiv_max', 'requiv_min', 'teff', 'abun', 'log
 _forbidden_labels += ['times', 'fluxes', 'sigmas', 'sigmas_lnf',
                      'compute_times', 'compute_phases', 'compute_phases_t0',
                      'phases_period', 'phases_dpdt', 'phases_t0', 'mask_enabled', 'mask_phases',
+                     'exclude_phases_enabled', 'exclude_phases',
                      'solver_times', 'expose_samples', 'expose_failed',
                      'ld_mode', 'ld_func', 'ld_coeffs', 'ld_coeffs_source',
                      'passband', 'intens_weighting',

--- a/tests/nosetests/test_forbidden_labels/test_forbidden_parameters.py
+++ b/tests/nosetests/test_forbidden_labels/test_forbidden_parameters.py
@@ -19,8 +19,8 @@ def test_forbidden(verbose=False):
     b.add_compute('ellc')
 
     b.add_spot(component='primary')
-    b.add_gp_sklearn(dataset='lc01')
-    b.add_gp_celerite2(dataset='lc01')
+    b.add_gaussian_process('sklearn', dataset='lc01')
+    b.add_gaussian_process('celerite2', dataset='lc01')
 
     b.add_solver('estimator.lc_periodogram')
     b.add_solver('estimator.rv_periodogram')

--- a/tests/nosetests/test_latexrepr/test_latexrepr.py
+++ b/tests/nosetests/test_latexrepr/test_latexrepr.py
@@ -18,8 +18,8 @@ def test_latexrepr(verbose=False):
     b.add_compute('ellc')
 
     b.add_spot(component='primary')
-    b.add_gp_sklearn(dataset='lc01')
-    b.add_gp_celerite2(dataset='lc01')
+    b.add_gaussian_process('sklearn', dataset='lc01')
+    b.add_gaussian_process('celerite2', dataset='lc01')
 
     for param in b.to_list():
         if verbose:


### PR DESCRIPTION
This PR tries to consolidate several frontend methods related to gaussian processes while keeping temporary support for syntax for the removed functionality in the upcoming release.

* keep the old `b.add/get/rename_gaussian_process` as opposed to per-kind methods
* `b.add_gaussian_process` accepts `kind` either with or without the `gp_` prefix (and defaults to 'sklearn')
* other methods pass `kind='gp_*'` to the relevant feature-level method
* b.add_feature('gaussian_process') now adds a celerite2 feature.  This is noted as deprecated - so we can remove it in a future release, but might be nice to have for now so the API docs and existing scripts don't suddenly completely break.

@gecheline - do you think these fallbacks (to default to 'sklearn' now, but to have the deprecated old name fallback to 'celerite2' make sense)?  If you don't see any other issues and CI passes, feel free to squash & merge (basic tests seem to do what I'd expect on my machine)!