### PR TITLE
move gp_exclude_phases parameters to compute context

### DIFF
--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -117,7 +117,10 @@ def phoebe(**kwargs):
 
     params += [BoolParameter(qualifier='enabled', copy_for={'context': 'dataset', 'dataset': '*'}, dataset='_default', value=kwargs.get('enabled', True), description='Whether to create synthetics in compute/solver run')]
     params += [BoolParameter(qualifier='enabled', copy_for={'context': 'feature', 'feature': '*'}, feature='_default', value=kwargs.get('enabled', True), description='Whether to enable the feature in compute/solver run')]
-    
+    params += [BoolParameter(visible_if='ds_has_enabled_feature:gp_*', qualifier='gp_exclude_phases_enabled', value=kwargs.get('gp_exclude_phases_enabled', True), copy_for={'kind': ['lc', 'rv', 'lp'], 'dataset': '*'}, dataset='_default', description='Whether to apply the mask in gp_exclude_phases during gaussian process fitting.')]
+    params += [FloatArrayParameter(visible_if='ds_has_enabled_feature:gp_*,gp_exclude_phases_enabled:True', qualifier='gp_exclude_phases', value=kwargs.get('gp_exclude_phases', []), copy_for={'kind': ['lc', 'rv', 'lp'], 'dataset': '*'}, dataset='_default', default_unit=u.dimensionless_unscaled, required_shape=[None, 2], description='List of phase-tuples.  Any observations inside the range set by any of the tuples will be ignored by the gaussian process features.')]
+
+
     # DYNAMICS
     params += [ChoiceParameter(qualifier='dynamics_method', value=kwargs.get('dynamics_method', 'keplerian'), choices=['keplerian'], description='Which method to use to determine the dynamics of components')]
     params += [BoolParameter(qualifier='ltte', value=kwargs.get('ltte', False), description='Correct for light travel time effects')]

--- a/phoebe/parameters/dataset.py
+++ b/phoebe/parameters/dataset.py
@@ -215,10 +215,6 @@ def lc(syn=False, as_ps=True, is_lc=True, **kwargs):
         params += [BoolParameter(qualifier='mask_enabled', value=kwargs.get('mask_enabled', True), description='Whether to apply the mask in mask_phases during plotting, calculate_residuals, calculate_chi2, calculate_lnlikelihood, and run_solver')]
         params += [FloatArrayParameter(visible_if='[component]mask_enabled:True', qualifier='mask_phases', component=kwargs.get('component_top', None), value=kwargs.get('mask_phases', []), default_unit=u.dimensionless_unscaled, required_shape=[None, 2], description='List of phase-tuples.  Any observations inside the range set by any of the tuples will be included.')]
 
-        # TODO: make these visible only if GPs attached
-        params += [BoolParameter(qualifier='exclude_phases_enabled', value=kwargs.get('mask_enabled', True), description='Whether to apply the mask in exclude_phases during Gaussian Process fitting.')]
-        params += [FloatArrayParameter(visible_if='[component]exclude_phases_enabled:True', qualifier='exclude_phases', component=kwargs.get('component_top', None), value=kwargs.get('exclude_phases', []), default_unit=u.dimensionless_unscaled, required_shape=[None, 2], description='List of phase-tuples.  Any observations inside the range set by any of the tuples will be ignored by the gaussian_process features.')]
-
         params += [ChoiceParameter(qualifier='solver_times', value=kwargs.get('solver_times', 'auto'), choices=['auto', 'compute_times', 'times'], description='times to use within run_solver.  All options will properly account for masking from mask_times.  To see how this is parsed, see b.parse_solver_times.  auto: use compute_times if provided and shorter than times, otherwise use times.  compute_times: use compute_times if provided.  times: use times array.')]
 
         params += [FloatArrayParameter(qualifier='sigmas', value=_empty_array(kwargs, 'sigmas'), required_shape=[None], default_unit=u.W/u.m**2, description='Observed uncertainty on flux')]

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -215,7 +215,7 @@ _forbidden_labels += ['requiv', 'requiv_max', 'requiv_min', 'teff', 'abun', 'log
 _forbidden_labels += ['times', 'fluxes', 'sigmas', 'sigmas_lnf',
                      'compute_times', 'compute_phases', 'compute_phases_t0',
                      'phases_period', 'phases_dpdt', 'phases_t0', 'mask_enabled', 'mask_phases',
-                     'exclude_phases_enabled', 'exclude_phases',
+                     'gp_exclude_phases_enabled', 'gp_exclude_phases',
                      'solver_times', 'expose_samples', 'expose_failed',
                      'ld_mode', 'ld_func', 'ld_coeffs', 'ld_coeffs_source',
                      'passband', 'intens_weighting',
@@ -7228,6 +7228,13 @@ class Parameter(object):
                     value = False
 
                 return getattr(hier, method)(self.component) == value
+
+            elif qualifier == 'ds_has_enabled_feature':
+                dataset = self.dataset
+                feature_kind = value
+                features_with_kind = self._bundle.filter(context='feature', kind=feature_kind, **_skip_filter_checks).features
+                enabled_features_with_kind = self._bundle.filter(qualifier='enabled', value=True, compute=self.compute, feature=features_with_kind, **_skip_filter_checks).features
+                return dataset in self._bundle.filter(context='feature', feature=enabled_features_with_kind, **_skip_filter_checks).datasets
 
             else:
 


### PR DESCRIPTION
`gp_exclude_phases` and `gp_exclude_phases_enabled` as per-dataset (via `copy_for`) in the compute context.  `visible_if` statements make these only visible for datasets in which there is an _enabled_ GP feature.

Example use:

```
import phoebe
b = phoebe.default_binary()
b.add_dataset('lc', compute_phases=phoebe.linspace(0,1,101))
```

The `gp_exclude_phases_enabled` and `gp_exclude_phases` parameters are hidden since no GP features have been added

```
print(b.filter(qualifier='gp_*', context='compute'))
b.add_feature('gp_sklearn', dataset='lc01')
print(b['feature'])
```


Now the parameters are visible, in the compute context and per-dataset.  Being in the compute context puts them with the `enabled` parameters and also allows creating different compute options with different options for how to handle the masking.

```
print(b.filter(qualifier='gp_*', context='compute'))
b.filter(qualifier='gp_*', context='compute').twigs
print(b.filter(qualifier='enabled', context='compute'))
```

Adding another feature attached to the same dataset will not make any difference (it will listen to the same parameters as above as they are per-dataset, not per-feature)

```
b.add_feature('gp_sklearn', dataset='lc01')
print(b.filter(qualifier='gp_*', context='compute'))
```

Turning off the enabled parameter hides the list parameter

```
b['gp_exclude_phases_enabled'] = False
print(b.filter(qualifier='gp_*', context='compute'))
b['gp_exclude_phases_enabled'] = True
print(b.filter(qualifier='gp_*', context='compute'))
```

Disabling the features also hides the parameters

```
print(b.filter(qualifier='enabled', feature='gp*', context='compute'))
b.set_value(qualifier='enabled', feature='gp_sklearn01', value=False)
print(b.filter(qualifier='gp_*', context='compute'))
b.set_value(qualifier='enabled', feature='gp_sklearn02', value=False)
print(b.filter(qualifier='gp_*', context='compute'))
b.set_value_all(qualifier='enabled', feature='gp_sklearn02', value=True)
print(b.filter(qualifier='gp_*', context='compute'))
```

Adding another dataset does NOT show more parameters, as the new dataset doesn't have any GPs (yet)

```
b.add_dataset('lc')
print(b.filter(qualifier='gp_*', context='compute'))
```

Once we attach a GP to the new dataset, the new parameters appear in the compute context, tagged with the dataset

```
b.add_feature('gp_sklearn', dataset='lc02')
print(b.filter(qualifier='gp_*', context='compute'))
b.filter(qualifier='gp_*', context='compute').twigs
```

Note: I think I updated the calls that make use of these parameters, but that should be checked against existing scripts.  Existing notebooks will probably need to be updated to add the `gp_` prefix, but as long as they don't use the context (and only refer to qualifier and dataset), they should otherwise work as-is.
