### PR TITLE
l3 handling distance in absolute pblum_mode bugfix (2.4.2 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.4.2 - l3 handling distance in absolute pblum_mode bugfix
+
+* fix conversion between l3 and l3_frac to account for distance when pblum_mode
+  is absolute
+* fix tagged phoebe version in cached bundles to avoid import warning
+
 ### 2.4.1 - solver filtering and plotting bugfix
 
 * fix filtering error when not explicitly passing solver to run_solver

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -17,7 +17,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.4.1'
+__version__ = '2.4.2'
 
 import os as _os
 import sys as _sys

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -758,8 +758,6 @@ def mpi_off():
 
 def multiprocessing_on():
     """
-    **NEW IN 2.3.26**
-
     Enable multiprocessing to use all CPUs available (this is the state by default).
     MPI will always take preference over multiprocessing.  See <phoebe.mpi_on>
     and <phoebe.mpi_off>.
@@ -777,8 +775,6 @@ def multiprocessing_on():
 
 def multiprocessing_off():
     """
-    **NEW IN 2.3.26**
-
     Disable multiprocessing and force serial mode (if MPI is also off: see
     <phoebe.mpi_on> and <phoebe.mpi_off>).
 
@@ -791,8 +787,6 @@ def multiprocessing_off():
 
 def multiprocessing_get_nprocs():
     """
-    **NEW IN 2.3.26**
-
     Get the number of processors used within multiprocessing.
 
     MPI will always take preference over multiprocessing.  See <phoebe.mpi_on>
@@ -811,8 +805,6 @@ def multiprocessing_get_nprocs():
 
 def multiprocessing_set_nprocs(nprocs):
     """
-    **NEW IN 2.3.26**
-
     Set a custom number of processors to use within multiprocessing.
     MPI will always take preference over multiprocessing.  See <phoebe.mpi_on>
     and <phoebe.mpi_off>.

--- a/phoebe/distortions/rotstar.py
+++ b/phoebe/distortions/rotstar.py
@@ -15,7 +15,7 @@ def rotfreq_to_omega(rotfreq, M_star, scale=c.R_sun.si.value, solar_units=False)
     ----------
     * `rotfreq` (float): rotation frequency of the star in cycles/day or cycles/s
         (see `solar_units`)
-    * `M_star` (float): **NEW IN 2.3.31** mass of the star (see `solar_units` for units)
+    * `M_star` (float): mass of the star (see `solar_units` for units)
     * `scale` (float, optional, default=c.R_sun.si.value)
     * `solar_units` (bool, optional, default=False): whether `rotfreq`, `M_star`,
         and `scale` are provided in solar units (instead of SI).

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10874,6 +10874,7 @@ class Bundle(ParameterSet):
         # finally, we'll loop through the datasets again to apply the scales to
         # determine the relative pblums, compute pbfluxes, and expose/set whatever
         # was requested
+        distance = self.get_value(qualifier='distance', context='system', unit=u.m, **_skip_filter_checks)
         for dataset in datasets:
             pblum_mode = self.get_value(qualifier='pblum_mode', dataset=dataset, pblum_mode=kwargs.get('pblum_mode', None), default='absolute', **_skip_filter_checks)
             if pblum_mode == 'dataset-scaled':
@@ -10915,6 +10916,8 @@ class Bundle(ParameterSet):
                 if self.hierarchy.get_kind_of(component) != 'envelope':
                     # don't want to double count
                     pbflux_this_dataset += pblum_rel / (4*np.pi)
+
+            pbflux_this_dataset /= distance**2
 
             if set_value:
                 self.set_value(qualifier='pbflux', dataset=dataset, context='dataset', value=pbflux_this_dataset*u.W/u.m**2, **_skip_filter_checks)

--- a/phoebe/frontend/default_bundles/default_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_binary.bundle
@@ -2519,7 +2519,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.0.dev1+phoebe_2.4dev",
+"value": "2.4.2",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_contact_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_contact_binary.bundle
@@ -2751,7 +2751,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.0.dev1+phoebe_2.4dev",
+"value": "2.4.2",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_star.bundle
+++ b/phoebe/frontend/default_bundles/default_star.bundle
@@ -1148,7 +1148,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.0.dev1+phoebe_2.4dev",
+"value": "2.4.2",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/parameters/constraint.py
+++ b/phoebe/parameters/constraint.py
@@ -2090,8 +2090,6 @@ def requiv_single_max(b, component, solve_for=None, **kwargs):
     Create a constraint to determine the critical value of requiv for a single
     star.
 
-    **NEW IN 2.3.31**
-
     This constraint is automatically created and attached for all single stars
     via <phoebe.frontend.bundle.Bundle.set_hierarchy>.
 

--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ else:
     long_description = "\n".join(long_description_s[long_description_s.index("INTRODUCTION"):])
 
 setup (name = 'phoebe',
-       version = '2.4.1',
+       version = '2.4.2',
        description = 'PHOEBE devel version',
        long_description=long_description,
        author = 'PHOEBE development team',
@@ -426,7 +426,7 @@ setup (name = 'phoebe',
             'Programming Language :: Python :: 3 :: Only',
         ],
        python_requires='>=3.6, <4',
-       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.4.1',
+       download_url = 'https://github.com/phoebe-project/phoebe2/tarball/2.4.2',
        packages = ['phoebe',
                    'phoebe.parameters', 'phoebe.parameters.solver', 'phoebe.parameters.figure',
                    'phoebe.frontend',


### PR DESCRIPTION
* fix conversion between l3 and l3_frac to account for distance when pblum_mode
  is absolute
* fix tagged phoebe version in cached bundles to avoid import warning