### PR TITLE
potential to requiv TypeError bugfix (2.4.6 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.4.6 - potential to requiv TypeError bugfix
+
+* fix bug where libphoebe was incorrectly raising an error suggesting the potential was out of bounds.
+
 ### 2.4.5 - negative mass bugfix
 
 * fix bug where mass could be set to a negative value causing constraints to resolve to nans.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -17,7 +17,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 
 import os as _os
 import sys as _sys

--- a/phoebe/constraints/builtin.py
+++ b/phoebe/constraints/builtin.py
@@ -299,8 +299,8 @@ def pot_to_requiv_contact(pot, q, sma, compno=1):
     try:
         logger.debug("libphoebe.roche_contact_neck_min(pi/2, q={}, d={}, pot={})".format(q, d, pot))
         nekmin = libphoebe.roche_contact_neck_min(np.pi / 2., q, d, pot)['xmin']
-        logger.debug("libphoebe.roche_contact_partial_area_volume(nekmin={}, q={}, d={}, pot={}, compno={})".format(nekmin, q, d, pot, compno-1))
-        volume_equiv = libphoebe.roche_contact_partial_area_volume(nekmin, q, d, pot, compno-1, lvolume=True, ldvolume=False, larea=False)['lvolume']
+        logger.debug("libphoebe.roche_contact_partial_area_volume(nekmin={}, q={}, d={}, pot={}, compno={})".format(nekmin, q, d, pot, int(compno-1)))
+        volume_equiv = libphoebe.roche_contact_partial_area_volume(nekmin, q, d, pot, int(compno-1), lvolume=True, ldvolume=False, larea=False)['lvolume']
         # returns normalized vequiv, should multiply by sma back for requiv in SI
         return sma * (3./4 * 1./np.pi * volume_equiv)**(1./3)
     except:

--- a/phoebe/frontend/default_bundles/default_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_binary.bundle
@@ -2522,7 +2522,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.5",
+"value": "2.4.6",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_contact_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_contact_binary.bundle
@@ -2754,7 +2754,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.5",
+"value": "2.4.6",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_star.bundle
+++ b/phoebe/frontend/default_bundles/default_star.bundle
@@ -1148,7 +1148,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.5",
+"value": "2.4.6",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ else:
     long_description = "\n".join(long_description_s[long_description_s.index("INTRODUCTION"):])
 
 setup (name = 'phoebe',
-       version = '2.4.5',
+       version = '2.4.6',
        description = 'PHOEBE 2.4',
        long_description=long_description,
        author = 'PHOEBE development team',


### PR DESCRIPTION
This fixes the bug reported in #658.'

* fix bug where libphoebe was incorrectly raising an error suggesting the potential was out of bounds.