### PR TITLE
Adds a private _remeshing_required() to Features (2.4.8 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.4.8 - spots optimization bugfix
+
+* spots no longer force the mesh to be recomputed at each timepoint.
+* updates for numpy compatibility and wider test matrix.
+
 ### 2.4.7 - line profile bugfix
 
 * fix bug where wavelength arrays that did not include the central wavelength were returning nans for fluxes.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -17,7 +17,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.4.7'
+__version__ = '2.4.8'
 
 import os as _os
 import sys as _sys

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -2007,7 +2007,13 @@ class Star_roche(Star):
         """
         # TODO: may be able to get away with removing the features check and just doing for pulsations, etc?
         # TODO: what about dpdt, deccdt, dincldt, etc?
-        return len(self.features) > 0 or self.is_misaligned or self.ecc != 0 or self.dynamics_method != 'keplerian'
+
+        if len(self.features) > 0:
+            for feature in self.features:
+                if feature._remeshing_required:
+                    return True
+        
+        return self.is_misaligned or self.ecc != 0 or self.dynamics_method != 'keplerian'
 
     @property
     def _rpole_func(self):
@@ -3016,9 +3022,19 @@ class Feature(object):
     In other words, its probably safest if each feature only overrides a
     SINGLE one of the methods.  Overriding multiple methods should be done
     with great care.
+
+    Each feature may or may not require recomputing a mesh, depending on the
+    kind of change it exacts to the mesh. For example, pulsations will require
+    recomputing a mesh while spots will not. By default, the mesh will be
+    recomputed (set in this superclass' `__init__()` method) but inherited
+    classes should overload `self.remeshing_required()`.
     """
     def __init__(self, *args, **kwargs):
         pass
+
+    @property
+    def _remeshing_required(self):
+        return True
 
     @property
     def proto_coords(self):
@@ -3122,6 +3138,10 @@ class Spot(Feature):
         t0 = b.get_value(qualifier='t0', context='system', unit=u.d, **_skip_filter_checks)
 
         return cls(colat, longitude, dlongdt, radius, relteff, t0)
+
+    @property
+    def _remeshing_required(self):
+        return False
 
     @property
     def proto_coords(self):

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -2008,10 +2008,9 @@ class Star_roche(Star):
         # TODO: may be able to get away with removing the features check and just doing for pulsations, etc?
         # TODO: what about dpdt, deccdt, dincldt, etc?
 
-        if len(self.features) > 0:
-            for feature in self.features:
-                if feature._remeshing_required:
-                    return True
+        for feature in self.features:
+            if feature._remeshing_required:
+                return True
         
         return self.is_misaligned or self.ecc != 0 or self.dynamics_method != 'keplerian'
 

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -3026,7 +3026,7 @@ class Feature(object):
     kind of change it exacts to the mesh. For example, pulsations will require
     recomputing a mesh while spots will not. By default, the mesh will be
     recomputed (set in this superclass' `__init__()` method) but inherited
-    classes should overload `self.remeshing_required()`.
+    classes should overload `self._remeshing_required`.
     """
     def __init__(self, *args, **kwargs):
         pass

--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ else:
     long_description = "\n".join(long_description_s[long_description_s.index("INTRODUCTION"):])
 
 setup (name = 'phoebe',
-       version = '2.4.7',
+       version = '2.4.8',
        description = 'PHOEBE 2.4',
        long_description=long_description,
        author = 'PHOEBE development team',


### PR DESCRIPTION
Any addition of a Feature immediately triggered mesh recomputing, if it was necessary or not. Now the Feature superclass defines a property-decorated _remeshing_required() method that defaults to True. Each subclass that does not require remeshing should overload it. This is the case for spots that do not affect the underlying mesh, so remeshing should not be done. This fixes #579.