### PR TITLE
recompute teffs for spots in async case

### DIFF
--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1998,7 +1998,9 @@ class Star_roche(Star):
 
     @property
     def needs_recompute_instantaneous(self):
-        return self.needs_remesh
+        # recompute instantaneous for asynchronous spots, even if meshing
+        # doesn't need to be recomputed
+        return self.needs_remesh or (len(self.features) and self.F != 1.0)
 
     @property
     def needs_remesh(self):
@@ -2011,7 +2013,7 @@ class Star_roche(Star):
         for feature in self.features:
             if feature._remeshing_required:
                 return True
-        
+
         return self.is_misaligned or self.ecc != 0 or self.dynamics_method != 'keplerian'
 
     @property
@@ -2422,6 +2424,12 @@ class Star_rotstar(Star):
     @property
     def is_convex(self):
         return True
+
+    @property
+    def needs_recompute_instantaneous(self):
+        # recompute instantaneous for asynchronous spots, even if meshing
+        # doesn't need to be recomputed
+        return self.needs_remesh or (len(self.features) and self.F != 1.0)
 
     @property
     def needs_remesh(self):


### PR DESCRIPTION
the mesh does not need to be recomputed for spots (as changed in 2.4.8 release in #638), but if the rotation is asynchronous, then the surface temperatures *do* need to be recomputed.