### PR TITLE
asynchronous spots bugfix (2.4.9 release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.4.9 - asynchronous spots bugfix
+
+* fixes bug introduced in 2.4.8 and ensures that temperatures are recomputed for spots when the star is rotating asynchronously.
+
 ### 2.4.8 - spots optimization bugfix
 
 * spots no longer force the mesh to be recomputed at each timepoint.

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -17,7 +17,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.4.8'
+__version__ = '2.4.9'
 
 import os as _os
 import sys as _sys

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1998,7 +1998,9 @@ class Star_roche(Star):
 
     @property
     def needs_recompute_instantaneous(self):
-        return self.needs_remesh
+        # recompute instantaneous for asynchronous spots, even if meshing
+        # doesn't need to be recomputed
+        return self.needs_remesh or (len(self.features) and self.F != 1.0)
 
     @property
     def needs_remesh(self):
@@ -2011,7 +2013,7 @@ class Star_roche(Star):
         for feature in self.features:
             if feature._remeshing_required:
                 return True
-        
+
         return self.is_misaligned or self.ecc != 0 or self.dynamics_method != 'keplerian'
 
     @property
@@ -2422,6 +2424,12 @@ class Star_rotstar(Star):
     @property
     def is_convex(self):
         return True
+
+    @property
+    def needs_recompute_instantaneous(self):
+        # recompute instantaneous for asynchronous spots, even if meshing
+        # doesn't need to be recomputed
+        return self.needs_remesh or (len(self.features) and self.F != 1.0)
 
     @property
     def needs_remesh(self):

--- a/setup.py
+++ b/setup.py
@@ -405,7 +405,7 @@ else:
     long_description = "\n".join(long_description_s[long_description_s.index("INTRODUCTION"):])
 
 setup (name = 'phoebe',
-       version = '2.4.8',
+       version = '2.4.9',
        description = 'PHOEBE 2.4',
        long_description=long_description,
        author = 'PHOEBE development team',


### PR DESCRIPTION
* fixes bug introduced in 2.4.8 and ensures that temperatures are recomputed for spots when the star is rotating asynchronously.