### PR TITLE
exposure time support for jktebop backend

### DIFF
--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -2145,11 +2145,8 @@ class JktebopBackend(BaseBackendByDataset):
         rA = b.get_value(qualifier='requiv', component=starrefs[0], context='component', unit=u.solRad, **_skip_filter_checks)
         rB = b.get_value(qualifier='requiv', component=starrefs[1], context='component', unit=u.solRad, **_skip_filter_checks)
         sma = b.get_value(qualifier='sma', component=orbitref, context='component', unit=u.solRad, **_skip_filter_checks)
-        sma_A = b.get_value(qualifier='sma', component=starrefs[0], context='component', unit=u.solRad, **_skip_filter_checks)
-        sma_B = b.get_value(qualifier='sma', component=starrefs[1], context='component', unit=u.solRad, **_skip_filter_checks)
         incl = b.get_value(qualifier='incl', component=orbitref, context='component', unit=u.deg, **_skip_filter_checks)
         q = b.get_value(qualifier='q', component=orbitref, context='component', **_skip_filter_checks)
-        ecc = b.get_value(qualifier='ecc', component=orbitref, context='component', **_skip_filter_checks)
         ecosw = b.get_value(qualifier='ecosw', component=orbitref, context='component', **_skip_filter_checks)
         esinw = b.get_value(qualifier='esinw', component=orbitref, context='component', **_skip_filter_checks)
 
@@ -2170,11 +2167,7 @@ class JktebopBackend(BaseBackendByDataset):
                     ecosw=ecosw, esinw=esinw,
                     gravbA=gravbA, gravbB=gravbB,
                     period=period, t0_supconj=t0_supconj,
-                    pblums=kwargs.get('pblums'),
-                    sma_A=sma_A,
-                    sma_B=sma_B,
-                    ecc=ecc
-                    )
+                    pblums=kwargs.get('pblums'))
 
     def _run_single_dataset(self, b, info, **kwargs):
         """
@@ -2190,15 +2183,12 @@ class JktebopBackend(BaseBackendByDataset):
         rA = kwargs.get('rA')
         rB = kwargs.get('rB')
         sma = kwargs.get('sma')
-        sma_A = kwargs.get('sma_A')
-        sma_B = kwargs.get('sma_B')
         incl = kwargs.get('incl')
         q = kwargs.get('q')
         if distortion_method == 'sphere':
             q *= -1
         ecosw = kwargs.get('ecosw')
         esinw = kwargs.get('esinw')
-        ecc = kwargs.get('ecc')
         gravbA = kwargs.get('gravbA')
         gravbB = kwargs.get('gravbB')
         period = kwargs.get('period')
@@ -2347,8 +2337,7 @@ class JktebopBackend(BaseBackendByDataset):
         #~ fi.write('rv2 llaqr-rv2.dat llaqr-rv2.out 55.0 -10.0 0 0\n')
         if info['kind'] == 'rv':
             # NOTE: we disable systemic velocity as it will be added in bundle.run_compute
-            sma_ = sma_A if info['component'] == starrefs[0] else sma_B
-            K = np.pi * 2*(sma_*u.solRad).to(u.km).value * np.sin((incl*u.deg).to(u.rad).value) / ((period*u.d).to(u.s).value * np.sqrt(1-ecc**2))
+            K = np.pi * (sma*u.solRad).to(u.km).value * np.sin((incl*u.deg).to(u.rad).value) / (period*u.d).to(u.s).value
             fi.write('{} {} {} {} {} 0 0\n'.format('rv1' if info['component'] == starrefs[0] else 'rv2', tmpfilenamervin, tmpfilenamervout, K, 0.0))
 
 

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -2145,8 +2145,11 @@ class JktebopBackend(BaseBackendByDataset):
         rA = b.get_value(qualifier='requiv', component=starrefs[0], context='component', unit=u.solRad, **_skip_filter_checks)
         rB = b.get_value(qualifier='requiv', component=starrefs[1], context='component', unit=u.solRad, **_skip_filter_checks)
         sma = b.get_value(qualifier='sma', component=orbitref, context='component', unit=u.solRad, **_skip_filter_checks)
+        sma_A = b.get_value(qualifier='sma', component=starrefs[0], context='component', unit=u.solRad, **_skip_filter_checks)
+        sma_B = b.get_value(qualifier='sma', component=starrefs[1], context='component', unit=u.solRad, **_skip_filter_checks)
         incl = b.get_value(qualifier='incl', component=orbitref, context='component', unit=u.deg, **_skip_filter_checks)
         q = b.get_value(qualifier='q', component=orbitref, context='component', **_skip_filter_checks)
+        ecc = b.get_value(qualifier='ecc', component=orbitref, context='component', **_skip_filter_checks)
         ecosw = b.get_value(qualifier='ecosw', component=orbitref, context='component', **_skip_filter_checks)
         esinw = b.get_value(qualifier='esinw', component=orbitref, context='component', **_skip_filter_checks)
 
@@ -2167,7 +2170,11 @@ class JktebopBackend(BaseBackendByDataset):
                     ecosw=ecosw, esinw=esinw,
                     gravbA=gravbA, gravbB=gravbB,
                     period=period, t0_supconj=t0_supconj,
-                    pblums=kwargs.get('pblums'))
+                    pblums=kwargs.get('pblums'),
+                    sma_A=sma_A,
+                    sma_B=sma_B,
+                    ecc=ecc
+                    )
 
     def _run_single_dataset(self, b, info, **kwargs):
         """
@@ -2183,12 +2190,15 @@ class JktebopBackend(BaseBackendByDataset):
         rA = kwargs.get('rA')
         rB = kwargs.get('rB')
         sma = kwargs.get('sma')
+        sma_A = kwargs.get('sma_A')
+        sma_B = kwargs.get('sma_B')
         incl = kwargs.get('incl')
         q = kwargs.get('q')
         if distortion_method == 'sphere':
             q *= -1
         ecosw = kwargs.get('ecosw')
         esinw = kwargs.get('esinw')
+        ecc = kwargs.get('ecc')
         gravbA = kwargs.get('gravbA')
         gravbB = kwargs.get('gravbB')
         period = kwargs.get('period')
@@ -2337,7 +2347,8 @@ class JktebopBackend(BaseBackendByDataset):
         #~ fi.write('rv2 llaqr-rv2.dat llaqr-rv2.out 55.0 -10.0 0 0\n')
         if info['kind'] == 'rv':
             # NOTE: we disable systemic velocity as it will be added in bundle.run_compute
-            K = np.pi * (sma*u.solRad).to(u.km).value * np.sin((incl*u.deg).to(u.rad).value) / (period*u.d).to(u.s).value
+            sma_ = sma_A if info['component'] == starrefs[0] else sma_B
+            K = np.pi * 2*(sma_*u.solRad).to(u.km).value * np.sin((incl*u.deg).to(u.rad).value) / ((period*u.d).to(u.s).value * np.sqrt(1-ecc**2))
             fi.write('{} {} {} {} {} 0 0\n'.format('rv1' if info['component'] == starrefs[0] else 'rv2', tmpfilenamervin, tmpfilenamervout, K, 0.0))
 
 

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -2221,6 +2221,23 @@ class JktebopBackend(BaseBackendByDataset):
             # TODO: provide a more useful error statement
             raise ValueError("jktebop only accepts the following options for ld_func: {}".format(ldfuncs.keys()))
 
+        # Check for finite integration time (should be an if statement instead of a try except)
+        try:
+            fti_oversample = b[f"fti_oversample@{info['dataset']}@{compute}"].value
+            exptime = b[f"exptime@{info['dataset']}"].value
+        except AttributeError:
+            fti_oversample = None
+            exptime = None
+
+        # fti_oversample = b.get_value(         # This fails for some reason with "two values present (jktebop, phoebe)" or "no value present"
+        #     qualifier='fti_oversample', dataset=info['dataset'], check_visible=True, check_default=True
+        # )
+        # exptime = b.get_value(qualifier='exptime', dataset=info['dataset'], check_visible=True, check_default=True)
+        if fti_oversample == 'none' or fti_oversample == 0:
+            fti_oversample = None
+        if exptime == 'none' or exptime == 0:
+            exptime = None
+
         # create the input file for jktebop
         # uncomment this block, comment out the following block and the os.remove at the end
         # for testing
@@ -2346,8 +2363,8 @@ class JktebopBackend(BaseBackendByDataset):
         # occupying a total time interval of NINTERVAL (seconds) by including this line:
         #   NUMI  [numint]  [ninterval]
 
-        # TODO: allow exposure times?
-
+        if fti_oversample is not None and exptime is not None:
+            fi.write(f'NUMINT {fti_oversample} {exptime}\n')
 
         fi.close()
 


### PR DESCRIPTION
This implements support for exposure times via fti_oversample in the jktebop alternate backend.

**TODO**:
- [ ] decide whether this should be in a bugfix (in which case needs API docs stating when it became available) or the next 2.5 release (in which case would need to be rebased)
- [ ] use filters instead of twigs (probably requires refactor in `compute.py` so that all backends that support exposure time can pull in those parameters)
- [ ] remove commented code
- [ ] test cases

Closes #700 