### PR TITLE
SelectParameters to receive tuple or array as input (not just list)

### DIFF
--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -8371,8 +8371,8 @@ class SelectParameter(Parameter):
         if isinstance(value, str):
             value = [value]
 
-        if not isinstance(value, list):
-            raise TypeError("value must be a list of strings, received {}".format(type(value)))
+        if not isinstance(value, (list, tuple, np.ndarray)):
+            raise TypeError("value must be a list, tuple, or array of strings, received {}".format(type(value)))
 
         try:
             value = [str(v) for v in value]


### PR DESCRIPTION
This PR allows SelectParameters to accept arrays or tuples in addition to lists.  For some reason, continuing an emcee solver run was passing `adopt_parameters` as an array and [raising a cryptic traceback](https://github.com/phoebe-project/phoebe2/discussions/718#discussioncomment-5402074).  This _should_ fix that case.