### PR TITLE
Import from within source tree overly restrictive

### DIFF
--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -27,9 +27,8 @@ import atexit
 import re
 
 # People shouldn't import phoebe from the root directory or from root/phoebe:
-cwd = _os.getcwd()
-root_dir = _os.path.abspath(_os.path.split(_os.path.split(__file__)[0])[0])
-if cwd == root_dir or _os.path.join(root_dir, 'phoebe') in _os.getcwd():
+_root_dir = _os.path.abspath(_os.path.split(_os.path.split(__file__)[0])[0])
+if _os.getcwd() == _root_dir or _os.path.join(_root_dir, 'phoebe') in _os.getcwd():
     # We have a clash of package name with the standard library: we implement an
     # "io" module and also they do. This means that you can import Phoebe from its
     # main source tree; then there is no difference between io from here and io

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -26,9 +26,10 @@ import multiprocessing as _multiprocessing
 import atexit
 import re
 
-# People shouldn't import Phoebe from the installation directory (inspired upon
-# pymc warning message).
-if _os.getcwd().find(_os.path.abspath(_os.path.split(_os.path.split(__file__)[0])[0]))>-1:
+# People shouldn't import phoebe from the root directory or from root/phoebe:
+cwd = _os.getcwd()
+root_dir = _os.path.abspath(_os.path.split(_os.path.split(__file__)[0])[0])
+if cwd == root_dir or _os.path.join(root_dir, 'phoebe') in _os.getcwd():
     # We have a clash of package name with the standard library: we implement an
     # "io" module and also they do. This means that you can import Phoebe from its
     # main source tree; then there is no difference between io from here and io


### PR DESCRIPTION
In order to avoid same-name module conflicts with the system module (such as io.py), phoebe shouldn't be imported from its own source tree. The original test eliminated the entire package tree, including all auxiliary directories, which is overly restrictive and it prevented pytest from running when phoebe was installed with `pip -e`. This PR fixes that by blocking imports from the root directory and from the root/phoebe tree (the actual sources). Closes #806.