### PR TITLE
Dynamical RVs now avoid meshing

### DIFF
--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -26,9 +26,9 @@ import multiprocessing as _multiprocessing
 import atexit
 import re
 
-# People shouldn't import Phoebe from the installation directory (inspired upon
-# pymc warning message).
-if _os.getcwd().find(_os.path.abspath(_os.path.split(_os.path.split(__file__)[0])[0]))>-1:
+# People shouldn't import phoebe from the root directory or from root/phoebe:
+_root_dir = _os.path.abspath(_os.path.split(_os.path.split(__file__)[0])[0])
+if _os.getcwd() == _root_dir or _os.path.join(_root_dir, 'phoebe') in _os.getcwd():
     # We have a clash of package name with the standard library: we implement an
     # "io" module and also they do. This means that you can import Phoebe from its
     # main source tree; then there is no difference between io from here and io

--- a/tests/tests/test_rvs/test_dynrvs.py
+++ b/tests/tests/test_rvs/test_dynrvs.py
@@ -1,0 +1,32 @@
+import phoebe
+import numpy as np
+
+
+def test_dynrvs(verbose=False):
+    """
+    This test checks whether PHOEBE computes dynamical RVs without building
+    a mesh, and whether the computed RVs are close to the flux-weighted RVs.
+    """
+    b = phoebe.default_binary()
+    b.add_dataset('rv', compute_times=phoebe.linspace(0, 1, 21), dataset='dynrv')
+    b.set_value_all('rv_method', 'dynamical')
+    b.set_value_all('teff', 1000000)
+    b.run_compute()
+
+    b.set_value_all('teff', 5772)
+    b.add_dataset('rv', compute_times=phoebe.linspace(0, 1, 21), dataset='fluxrv')
+    b.set_value('rv_method', component='primary', dataset='fluxrv', value='flux-weighted')
+    b.set_value('rv_method', component='secondary', dataset='fluxrv', value='flux-weighted')
+    b.run_compute(eclipse_method='only_horizon')
+
+    if verbose:
+        print('maximum primary RV offset:', np.abs(b['value@rvs@primary@dynrv']-b['value@rvs@primary@fluxrv']).max())
+        print('maximum secondary RV offset:', np.abs(b['value@rvs@secondary@dynrv']-b['value@rvs@secondary@fluxrv']).max())
+
+    assert np.allclose(b['value@rvs@primary@dynrv'], b['value@rvs@primary@fluxrv'], atol=0.3)
+    assert np.allclose(b['value@rvs@secondary@dynrv'], b['value@rvs@secondary@fluxrv'], atol=0.3)
+
+
+if __name__ == '__main__':
+    logger = phoebe.logger(clevel='INFO')
+    test_dynrvs(verbose=True)


### PR DESCRIPTION
Calling b.compute_pblums() built the mesh and treated dynamical RVs as mesh-dependent. This fixes that for both run_compute() and for direct compute_pblums(), compute_l3(), and compute_ld_coeffs bundle methods. A new function, b._datasets_that_require_meshing(), filters datasets that require a mesh, i.e. 'lc', 'lp' and flux-weighted 'rv'. Closes #812.