### PR TITLE
Dynamical RVs now avoid meshing

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10389,7 +10389,7 @@ class Bundle(ParameterSet):
         return system
 
     def _datasets_where(self, compute, mesh_needed=False, l3_needed=False):
-        datasets = self.filter(compute=compute, qualifier='enabled', value=True, **_skip_filter_checks).datasets
+        datasets = self.filter(compute=compute, context='compute', qualifier='enabled', value=True, **_skip_filter_checks).datasets
         ds_kinds = [self.filter(dataset=ds, context='dataset', **_skip_filter_checks).kind for ds in datasets]
         backend = self.filter(compute=compute, context='compute', **_skip_filter_checks).kind
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10461,7 +10461,7 @@ class Bundle(ParameterSet):
             raise TypeError("compute must be a single value (string)")
 
         # either take user-passed datasets or datasets that have an l3_mode:
-        datasets = kwargs.pop('dataset', self._datasets_where(compute=compute, l3_needed=True))
+        datasets = kwargs.pop('dataset') if 'dataset' in kwargs else self._datasets_where(compute=compute, l3_needed=True)
         if isinstance(datasets, str):
             datasets = [datasets]
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10391,7 +10391,7 @@ class Bundle(ParameterSet):
     def _datasets_where(self, compute, mesh_needed=False, l3_needed=False):
         datasets = self.filter(compute=compute, qualifier='enabled', value=True, **_skip_filter_checks).datasets
         ds_kinds = [self.filter(dataset=ds, context='dataset', **_skip_filter_checks).kind for ds in datasets]
-        backend = self.filter(compute=compute).kind
+        backend = self.filter(compute=compute, context='compute', **_skip_filter_checks).kind
 
         subset = []
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10396,7 +10396,7 @@ class Bundle(ParameterSet):
         subset = []
 
         if l3_needed:
-            subset += [ds for ds in datasets if len(self.filter('l3_mode', dataset=ds, check_visible=True)) > 0]
+            subset += [ds for ds in datasets if len(self.filter(qualifier='l3_mode', dataset=ds, context='dataset', check_visible=True)) > 0]
 
         if mesh_needed:
             subset += [ds for ds, kind in zip(datasets, ds_kinds) 

--- a/tests/tests/test_rvs/test_dynrvs.py
+++ b/tests/tests/test_rvs/test_dynrvs.py
@@ -1,0 +1,32 @@
+import phoebe
+import numpy as np
+
+
+def test_dynrvs(verbose=False):
+    """
+    This test checks whether PHOEBE computes dynamical RVs without building
+    a mesh, and whether the computed RVs are close to the flux-weighted RVs.
+    """
+    b = phoebe.default_binary()
+    b.add_dataset('rv', compute_times=phoebe.linspace(0, 1, 21), dataset='dynrv')
+    b.set_value_all('rv_method', 'dynamical')
+    b.set_value_all('teff', 1000000)
+    b.run_compute()
+
+    b.set_value_all('teff', 5772)
+    b.add_dataset('rv', compute_times=phoebe.linspace(0, 1, 21), dataset='fluxrv')
+    b.set_value('rv_method', component='primary', dataset='fluxrv', value='flux-weighted')
+    b.set_value('rv_method', component='secondary', dataset='fluxrv', value='flux-weighted')
+    b.run_compute(eclipse_method='only_horizon')
+
+    if verbose:
+        print('maximum primary RV offset:', np.abs(b['value@rvs@primary@dynrv']-b['value@rvs@primary@fluxrv']).max())
+        print('maximum secondary RV offset:', np.abs(b['value@rvs@secondary@dynrv']-b['value@rvs@secondary@fluxrv']).max())
+
+    assert np.allclose(b['value@rvs@primary@dynrv'], b['value@rvs@primary@fluxrv'], atol=0.3)
+    assert np.allclose(b['value@rvs@secondary@dynrv'], b['value@rvs@secondary@fluxrv'], atol=0.3)
+
+
+if __name__ == '__main__':
+    logger = phoebe.logger(clevel='INFO')
+    test_dynrvs(verbose=True)

--- a/tests/tests/test_rvs/test_dynrvs.py
+++ b/tests/tests/test_rvs/test_dynrvs.py
@@ -5,7 +5,8 @@ import numpy as np
 def test_dynrvs(verbose=False):
     """
     This test checks whether PHOEBE computes dynamical RVs without building
-    a mesh, and whether the computed RVs are close to the flux-weighted RVs.
+    a mesh (as otherwise run_compute would fail with atm out-of-bounds errors), 
+    and whether the computed RVs are close to the flux-weighted RVs.
     """
     b = phoebe.default_binary()
     b.add_dataset('rv', compute_times=phoebe.linspace(0, 1, 21), dataset='dynrv')


### PR DESCRIPTION
Calling b.compute_pblums() built the mesh and treated dynamical RVs as mesh-dependent. This fixes that for both run_compute() and for direct compute_pblums(), compute_l3(), and compute_ld_coeffs bundle methods. A new function, b._datasets_that_require_meshing(), filters datasets that require a mesh, i.e. 'lc', 'lp' and flux-weighted 'rv'. Closes #812.