### PR TITLE
Fix MPI off to not broadcast if never enabled

### DIFF
--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -162,7 +162,7 @@ class MPI(object):
             self.nprocs = nprocs
 
     def off(self):
-        if self.within_mpirun and self.myrank == 0:
+        if self.within_mpirun and self.enabled and self.myrank == 0:
             self.comm.bcast({'worker_command': 'release'}, root=0)
 
         self._enabled = False


### PR DESCRIPTION
when turning mpi off, don't broadcast if mpi was never enabled

fixes #845