### PR TITLE
Bugfix - datasets now converted to list as intended in compute_ld_coeffs

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10257,6 +10257,8 @@ class Bundle(ParameterSet):
             raise TypeError("compute must be a single value (string)")
 
         datasets = kwargs.pop('dataset') if 'dataset' in kwargs else self._datasets_where(compute=compute, mesh_needed=True)
+        if isinstance(datasets, str):
+            datasets = [datasets]
 
         # we'll add 'bol' to the list of default datasets... but only if bolometric is needed for irradiation
         compute_ps = self.get_compute(compute, **_skip_filter_checks)


### PR DESCRIPTION
In bundle.py the function `compute_ld_coeffs` was missing logic to convert datasets into a list before trying to append an additional dataset.  This caused an error pointed out in the following issue: https://github.com/phoebe-project/phoebe2-docs/issues/36

We have added the missing logic and now the error no longer occurs.