### PR TITLE
fix multi-compute with enabled/disabled datasets

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -12141,7 +12141,7 @@ class Bundle(ParameterSet):
                             continue
 
                         fluxes = flux_param.get_value(unit=u.W/u.m**2)
-                        fluxes = fluxes/distance**2 + l3s.get(dataset)
+                        fluxes = fluxes/distance**2 + l3s.get(dataset, 0.0)
 
                         flux_param.set_value(fluxes, ignore_readonly=True)
 


### PR DESCRIPTION
This PR fixes a traceback when using multiple computes with datasets disabled in some of the computes.  Previously, this raised the following error:

```
  File "phoebe2/phoebe/frontend/bundle.py", line 12147, in run_compute
    fluxes = fluxes/distance**2 + l3s.get(dataset)
             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```