### PR TITLE
helper functions to calculate lc/rv from mesh models

### DIFF
--- a/phoebe/helpers/__init__.py
+++ b/phoebe/helpers/__init__.py
@@ -469,10 +469,10 @@ def get_unit_in_system(original_unit, system):
         raise NotImplementedError("system must be 'si' or 'solar'")
 
 
-def integrate_flux_from_mesh(b, model, mesh_dataset, lc_dataset):
+def fluxes_from_mesh_model(b, model, mesh_dataset, lc_dataset):
     """
-    Integrate the flux from a mesh at each time in a model.  The following columns must have been exposed in the mesh,
-    otherwise an error will be raised:
+    Calculate the flux from a mesh at each time in a model by integrating over the surface elements.
+    The following columns must have been exposed in the mesh, otherwise an error will be raised:
 
     * `visibilities`
     * `intensities`
@@ -489,7 +489,7 @@ def integrate_flux_from_mesh(b, model, mesh_dataset, lc_dataset):
 
     Returns
     -----------------
-    * unit
+    * times (array), fluxes (array)
     """
     model_ps = b.get_model(model=model, context='model', dataset=(mesh_dataset, lc_dataset), **_skip_filter_checks)
     for qualifier in ('visibilities', 'intensities', 'areas', 'mus', 'ptfarea'):
@@ -509,3 +509,49 @@ def integrate_flux_from_mesh(b, model, mesh_dataset, lc_dataset):
             flux += np.nansum(intensities*areas*mus*visibilities)*ptfarea
         fluxes[i] = float(flux)
     return times, fluxes
+
+
+def rvs_from_mesh_model(b, model, mesh_dataset, rv_dataset, component):
+    """
+    Calculate the RV from a mesh at each time in a model. 
+    The following columns must have been exposed in the mesh, otherwise an error will be raised:
+
+    * `vws`
+    * `visibilities`
+    * `abs_intensities`
+    * `areas`
+    * `mus`
+
+        Arguments
+    -----------------
+    * `b` (<phoebe.frontend.bundle.Bundle>): the Bundle
+    * `model` (string): model containing the mesh
+    * `mesh_dataset` (string): label of the mesh dataset in the model
+    * `rv_dataset` (string): label of the rv dataset in the model
+    * `component` (string): label of the component to compute the RVs (call successively for primary and secondary RVs)
+
+    Returns
+    -----------------
+    * times (array), rvs (array)
+    """
+    model_ps = b.get_model(model=model, context='model', component=component, 
+                           dataset=(mesh_dataset, rv_dataset), **_skip_filter_checks)
+    for qualifier in ('vws', 'visibilities', 'abs_intensities', 'areas', 'mus'):
+        if qualifier not in model_ps.qualifiers:
+            raise ValueError("model must have {} to calculate RVs".format(qualifier))
+    times = np.asarray(model_ps.times, float)
+    rvs = np.zeros_like(times)
+    for i, time in enumerate(times):
+        model_ps_tc = model_ps.filter(time=time, **_skip_filter_checks)
+        visibilities = model_ps_tc.get_value(qualifier='visibilities', **_skip_filter_checks)
+        if np.all(visibilities==0):
+            # then no triangles are visible, so we should return nan
+            rvs[i] = np.nan
+            continue
+        vws = model_ps_tc.get_value(qualifier='vws', **_skip_filter_checks)
+        abs_intensities = model_ps_tc.get_value(qualifier='abs_intensities', **_skip_filter_checks)
+        areas = model_ps_tc.get_value(qualifier='areas', unit='m^2', **_skip_filter_checks)
+        mus = model_ps_tc.get_value(qualifier='mus', **_skip_filter_checks)
+        inds = np.where(visibilities > 0)
+        rvs[i] = np.average(-vws[inds], weights=(abs_intensities*areas*mus*visibilities)[inds])
+    return times, rvs

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -2742,7 +2742,7 @@ class ParameterSet(object):
             for k, v in kwargs.items():
                 if k in _meta_fields_filter:
                     ps._filter[k] = v
-            if twig is not None and not isinstance(twig, list):
+            if twig is not None and not isinstance(twig, (list, tuple)):
                 # try to guess necessary additions to filter
                 twigsplit = twig.split('@')
                 for attr in _meta_fields_twig:
@@ -2757,7 +2757,7 @@ class ParameterSet(object):
             # of the Parameters hidden by this switch
             check_default = False
 
-        if isinstance(twig, list):
+        if isinstance(twig, (list, tuple)):
             params = []
             for t in twig:
                 params += self.filter(twig=t, check_visible=check_visible, check_default=check_default, check_advanced=check_advanced, check_single=check_single, **kwargs).to_list()
@@ -2814,10 +2814,10 @@ class ParameterSet(object):
                     key in _meta_fields_filter and \
                     kwargs[key] is not None:
 
-                params = [pi for pi in params if (hasattr(pi,key) and getattr(pi,key) is not None or isinstance(kwargs[key], list) and None in kwargs[key]) and
+                params = [pi for pi in params if (hasattr(pi,key) and getattr(pi,key) is not None or isinstance(kwargs[key], (list, tuple)) and None in kwargs[key]) and
                     (getattr(pi,key) is kwargs[key] or
-                    (isinstance(kwargs[key],list) and getattr(pi,key) in kwargs[key]) or
-                    (isinstance(kwargs[key],list) and np.any([_fnmatch(getattr(pi,key),keyi) for keyi in kwargs[key]])) or
+                    (isinstance(kwargs[key], (list, tuple)) and getattr(pi,key) in kwargs[key]) or
+                    (isinstance(kwargs[key], (list, tuple)) and np.any([_fnmatch(getattr(pi,key),keyi) for keyi in kwargs[key]])) or
                     (isinstance(kwargs[key],str) and isinstance(getattr(pi,key),str) and _fnmatch(getattr(pi,key),kwargs[key])) or
                     (key=='kind' and isinstance(kwargs[key],str) and getattr(pi,key).lower()==kwargs[key].lower()) or
                     (key=='kind' and hasattr(kwargs[key],'__iter__') and getattr(pi,key).lower() in [k.lower() for k in kwargs[key]]) or
@@ -6033,7 +6033,7 @@ class ParameterSet(object):
                 time = self._bundle.get_value(time, context=['component', 'system'], check_visible=False)
 
             # plotting doesn't currently support highlighting at multiple times
-            # if isinstance(time, list) or isinstance(time, tuple):
+            # if isinstance(time, (list, tuple)):
             #     user_time = time
             #     time = []
             #     for t in user_time:
@@ -6565,7 +6565,7 @@ class Parameter(object):
                 return v
             elif isinstance(v, dict):
                 return v
-            elif isinstance(v, float) or isinstance(v, int) or isinstance(v, list):
+            elif isinstance(v, float) or isinstance(v, int) or isinstance(v, (list, tuple)):
                 return v
             elif _is_unit(v):
                 return str(v.to_string())

--- a/tests/tests/test_helpers/test_helpers.py
+++ b/tests/tests/test_helpers/test_helpers.py
@@ -10,17 +10,39 @@ def test_integrate_flux_from_mesh():
     b.run_compute(model='latest')
 
     with pytest.raises(ValueError):
-        phoebe.helpers.integrate_flux_from_mesh(b, 'latest', 'mesh01', 'lc01')
+        phoebe.helpers.fluxes_from_mesh_model(b, 'latest', 'mesh01', 'lc01')
 
     b.set_value('columns', value=['visibilities', 'intensities@lc01', 'areas', 'ptfarea@lc01', 'mus'])
     b.run_compute(model='latest')
 
-    times, fluxes = phoebe.helpers.integrate_flux_from_mesh(b, 'latest', 'mesh01', 'lc01')
+    times, fluxes = phoebe.helpers.fluxes_from_mesh_model(b, 'latest', 'mesh01', 'lc01')
     assert len(times) == 4
     assert len(fluxes) == 4
 
-    fluxes_lc = b.get_value(qualifier='fluxes', dataset='lc01', context='model')
-    assert_allclose(fluxes, fluxes_lc, atol=5e-5)
+    fluxes_ml = b.get_value(qualifier='fluxes', dataset='lc01', context='model')
+    assert_allclose(fluxes, fluxes_ml, atol=5e-5)
+
+def test_integrate_rv_from_mesh():
+    b = phoebe.default_binary()
+    b.set_value(qualifier='q', value=0.95)
+    b.add_dataset('rv', times=phoebe.linspace(0,1,4), dataset='rv01')
+    b.add_dataset('mesh', include_times='rv01', dataset='mesh01')
+    b.run_compute(model='latest')
+
+    with pytest.raises(ValueError):
+        phoebe.helpers.rvs_from_mesh_model(b, 'latest', 'mesh01', 'rv01', 'primary')
+
+    b.set_value(qualifier='columns', value=['vws', 'visibilities', 'abs_intensities@rv01', 'areas', 'mus'])
+    b.run_compute(model='latest')
+
+    for comp in ('primary', 'secondary'):
+        times, rvs = phoebe.helpers.rvs_from_mesh_model(b, 'latest', 'mesh01', 'rv01', comp)
+        assert len(times) == 4
+        assert len(rvs) == 4
+
+        rvs_ml = b.get_value(qualifier='rvs', dataset='rv01', component=comp, context='model')
+        assert_allclose(rvs, rvs_ml, atol=5e-5)
 
 if __name__ == '__main__':
     test_integrate_flux_from_mesh()
+    test_integrate_rv_from_mesh()

--- a/tests/tests/test_helpers/test_helpers.py
+++ b/tests/tests/test_helpers/test_helpers.py
@@ -1,0 +1,26 @@
+import phoebe
+import pytest
+from numpy.testing import assert_allclose
+
+
+def test_integrate_flux_from_mesh():
+    b = phoebe.default_binary()
+    b.add_dataset('lc', compute_phases=phoebe.linspace(0,1,4), dataset='lc01')
+    b.add_dataset('mesh', include_times='lc01', dataset='mesh01')
+    b.run_compute(model='latest')
+
+    with pytest.raises(ValueError):
+        phoebe.helpers.integrate_flux_from_mesh(b, 'latest', 'mesh01', 'lc01')
+
+    b.set_value('columns', value=['visibilities', 'intensities@lc01', 'areas', 'ptfarea@lc01', 'mus'])
+    b.run_compute(model='latest')
+
+    times, fluxes = phoebe.helpers.integrate_flux_from_mesh(b, 'latest', 'mesh01', 'lc01')
+    assert len(times) == 4
+    assert len(fluxes) == 4
+
+    fluxes_lc = b.get_value(qualifier='fluxes', dataset='lc01', context='model')
+    assert_allclose(fluxes, fluxes_lc, atol=5e-5)
+
+if __name__ == '__main__':
+    test_integrate_flux_from_mesh()


### PR DESCRIPTION
This is a WIP for adding helper-functions to allow computing the light curve or RV from a mesh (allowing to modify the mesh in the frontend and then handle the integration/weighting to determine the flux/RV).

TODO:
- [ ] investigate/fix failing assertion in RV CI
- [ ] ticket for example notebook for modifying mesh and using helper method

