### PR TITLE
fix requivfrac units

### DIFF
--- a/phoebe/parameters/constraint.py
+++ b/phoebe/parameters/constraint.py
@@ -1999,7 +1999,7 @@ def requivfrac(b, component, solve_for=None, **kwargs):
 
     metawargs = component_ps.meta
     metawargs.pop('qualifier')
-    requivfrac_def = FloatParameter(qualifier='requivfrac', latexfmt=r'R_\mathrm{{ {component} }} / a_\mathrm{{ {parent} }}', value=1.0, default_unit=u.solRad, advanced=True, description='Fractional equivalent radius')
+    requivfrac_def = FloatParameter(qualifier='requivfrac', latexfmt=r'R_\mathrm{{ {component} }} / a_\mathrm{{ {parent} }}', value=1.0, default_unit=u.dimensionless_unscaled, advanced=True, description='Fractional equivalent radius')
     requivfrac, created = b.get_or_create('requivfrac', requivfrac_def, **metawargs)
 
     requiv = component_ps.get_parameter(qualifier='requiv', **_skip_filter_checks)


### PR DESCRIPTION
This PR fixes the units on the optional `requivfrac` parameter to be unitless.  

Fixes #690 (I could not reproduce the actual distributions problem anymore and I think that was fixed in 2.4.4 - but the unit issue remained and is fixed here).  The following code now works:

```
import phoebe

b = phoebe.default_binary()

b.add_constraint('requivfrac', component='primary')
b.add_constraint('requivfrac', component='secondary')
b.flip_constraint('requivfrac@primary', solve_for='requiv@primary')
b.flip_constraint('requivfrac@secondary', solve_for='requiv@secondary')

b.add_distribution({'teffratio': phoebe.gaussian_around(10),
                    'requivfrac@primary': phoebe.gaussian_around(0.1),
                    'incl@binary': phoebe.gaussian_around(0.1),
                    'q': phoebe.gaussian_around(0.1),
                    'asini@binary': phoebe.gaussian_around(1),
                    'teff@primary': phoebe.gaussian_around(100),
                    'requivfrac@secondary': phoebe.gaussian_around(0.1),
                    't0_supconj': phoebe.gaussian_around(1)},
                  distribution='test_dist')
b.uncertainties_from_distribution_collection(distribution='test_dist', parameters=['requiv@secondary'], sigma=3, tex=True)
```

<img width="216" alt="image" src="https://github.com/phoebe-project/phoebe2/assets/877591/43bb7f37-87bb-44cb-b11e-fee29cbeb631">
