### PR TITLE
emcee move feature

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -5537,12 +5537,11 @@ class Bundle(ParameterSet):
         return deps_pip, deps_other
 
     @send_if_client
-    def add_feature(self, kind, component=None, dataset=None,
+    def add_feature(self, kind, component=None, dataset=None, solver=None,
                     return_changes= False, **kwargs):
         """
-        Add a new feature (spot, gaussian process, etc) to a component or
-        dataset in the system.  If not
-        provided, `feature` (the name of the new feature) will be created
+        Add a new feature (spot, gaussian process, etc) to a component, dataset,
+        or solver.  If not provided, `feature` (the name of the new feature) will be created
         for you and can be accessed by the `feature` attribute of the returned
         <phoebe.parameters.ParameterSet>.
 
@@ -5561,10 +5560,11 @@ class Bundle(ParameterSet):
         * <phoebe.parameters.feature.spot>
         * <phoebe.parameters.feature.gp_sklearn>
         * <phoebe.parameters.feature.gp_celerite2>
+        * <phoebe.parameters.feature.emcee_move>
 
-        See the entries above to see the valid kinds for `component` and `dataset`
-        based on the type of feature.  An error will be raised if the passed value
-        for `component` and/or `dataset` are not allowed by the type of feature
+        See the entries above to see the valid kinds for `component`, `dataset`,
+        and `solver` based on the type of feature.  An error will be raised if the passed value
+        for `component`, `dataset`, or `solver` are not allowed by the type of feature
         with kind `kind`.
 
         Arguments
@@ -5579,6 +5579,8 @@ class Bundle(ParameterSet):
             feature.  Required for features that must be attached to a component.
         * `dataset` (string, optional): name of the dataset to attach the feature.
             Required for features that must be attached to a dataset.
+        * `solver` (string, optional): name of the solver to attach the feature.
+            Required for features that must be attached to a solver.
         * `feature` (string, optional): name of the newly-created feature.
         * `overwrite` (boolean, optional, default=False): whether to overwrite
             an existing feature with the same `feature` tag.  If False,
@@ -5637,11 +5639,23 @@ class Bundle(ParameterSet):
         if not _feature._dataset_allowed_for_feature(func.__name__, dataset_kind):
             raise ValueError("{} does not support dataset with kind {}".format(func.__name__, dataset_kind))
 
+        if solver is not None:
+            if solver not in self.solvers:
+                raise ValueError("solver '{}' not one of {}".format(solver, self.solvers))
+
+            solver_kind = self.filter(solver=solver, context='solver').kind
+        else:
+            solver_kind = None
+
+        if not _feature._solver_allowed_for_feature(func.__name__, solver_kind):
+            raise ValueError("{} does not support solver with kind {}".format(func.__name__, solver_kind))
+
         params, constraints = func(**kwargs)
 
         metawargs = {'context': 'feature',
                      'component': component,
                      'dataset': dataset,
+                     'solver': solver,
                      'feature': kwargs['feature'],
                      'kind': func.__name__}
 

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -115,7 +115,7 @@ def phoebe(**kwargs):
     params += _server_params(**kwargs)
 
     params += [BoolParameter(qualifier='enabled', copy_for={'context': 'dataset', 'dataset': '*'}, dataset='_default', value=kwargs.get('enabled', True), description='Whether to create synthetics in compute/solver run')]
-    params += [BoolParameter(qualifier='enabled', copy_for={'context': 'feature', 'feature': '*'}, feature='_default', value=kwargs.get('enabled', True), description='Whether to enable the feature in compute/solver run')]
+    params += [BoolParameter(qualifier='enabled', copy_for={'context': 'feature', 'kind': ['spot', 'gp_sklearn', 'gp_celerite2'], 'feature': '*'}, feature='_default', value=kwargs.get('enabled', True), description='Whether to enable the feature in compute/solver run')]
     params += [BoolParameter(visible_if='ds_has_enabled_feature:gp_*', qualifier='gp_exclude_phases_enabled', value=kwargs.get('gp_exclude_phases_enabled', True), copy_for={'kind': ['lc', 'rv', 'lp'], 'dataset': '*'}, dataset='_default', description='Whether to apply the mask in gp_exclude_phases during gaussian process fitting.')]
     params += [FloatArrayParameter(visible_if='ds_has_enabled_feature:gp_*,gp_exclude_phases_enabled:True', qualifier='gp_exclude_phases', value=kwargs.get('gp_exclude_phases', []), copy_for={'kind': ['lc', 'rv', 'lp'], 'dataset': '*'}, dataset='_default', default_unit=u.dimensionless_unscaled, required_shape=[None, 2], description='List of phase-tuples.  Any observations inside the range set by any of the tuples will be ignored by the gaussian process features.')]
 

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -181,7 +181,7 @@ _forbidden_labels += ['bol']
 # forbid all kinds
 _forbidden_labels += ['lc', 'rv', 'lp', 'sp', 'orb', 'mesh']
 _forbidden_labels += ['star', 'orbit', 'envelope']
-_forbidden_labels += ['spot', 'pulsation']
+_forbidden_labels += ['spot', 'pulsation', 'gaussian_process', 'emcee_move']
 _forbidden_labels += ['phoebe', 'legacy', 'jktebop', 'ellc']
 
 
@@ -301,6 +301,7 @@ _forbidden_labels += ['colat', 'long', 'radius', 'relteff',
                       'sigma_0', 'constant_value_bounds', 'length_scale_bounds',
                       'noise_level_bounds', 'periodicity_bounds', 'alpha_bounds', 'nu_bounds',
                       'sigma_0_bounds', 'alg_operation',
+                      'move', 'weight', 'a', 'smode', 's', 'bw_method', 'bw_constant'
                       ]
 
 # from figure:

--- a/phoebe/parameters/solver/sampler.py
+++ b/phoebe/parameters/solver/sampler.py
@@ -130,6 +130,8 @@ def emcee(**kwargs):
     params = _comments_params(**kwargs)
     params += _server_params(**kwargs)
 
+    params += [BoolParameter(qualifier='enabled', copy_for={'context': 'feature', 'kind': ['emcee_move'], 'feature': '*'}, feature='_default', value=kwargs.get('enabled', True), description='Whether to enable the feature in compute/solver run')]
+
     params += [ChoiceParameter(qualifier='compute', value=kwargs.get('compute', 'None'), choices=['None'], description='compute options to use for forward model')]
 
     params += [ChoiceParameter(qualifier='continue_from', value=kwargs.get('continue_from', 'None'), choices=['None'], description='continue the MCMC run from an existing emcee solution.  Chains will be appended to existing chains (so it is safe to overwrite the existing solution).  If None, will start a new run using init_from.')]

--- a/phoebe/solverbackends/solverbackends.py
+++ b/phoebe/solverbackends/solverbackends.py
@@ -1629,8 +1629,32 @@ class EmceeBackend(BaseSolverBackend):
             esargs['ndim'] = len(params_uniqueids)
             esargs['log_prob_fn'] = _lnprobability
             # esargs['a'] = kwargs.pop('a', None),
-            # esargs['moves'] = kwargs.pop('moves', None)
             # esargs['args'] = None
+
+            enabled_solver_features = b.filter(qualifier='enabled', value=True, solver=solver, **_skip_filter_checks).features
+            enabled_moves = b.filter(feature=enabled_solver_features, kind='emcee_move', **_skip_filter_checks).features
+            if len(enabled_moves):
+                logger.info("enabled moves: {}".format(enabled_moves))
+                moves = []
+                weights_sum = np.sum([b.get_value(qualifier='weight', feature=move, **_skip_filter_checks) for move in enabled_moves])
+                for move_feature in enabled_moves:
+                    move_feature_ps = b.get_feature(feature=move_feature, check_visible=True)
+                    move_class = move_feature_ps.get_value(qualifier='move', **_skip_filter_checks)
+                    move_weight = move_feature_ps.get_value(qualifier='weight') / weights_sum
+                    move_kwargs = {p.qualifier: p.get_value() for p in move_feature_ps.to_list() if p.qualifier not in ['move', 'weight']}
+                    if move_kwargs.pop('smode', None) == 'auto':
+                        move_kwargs['s'] = None
+                    if move_kwargs.get('bw_method', None) == 'constant':
+                        move_kwargs['bw_method'] = move_kwargs.pop('bw_constant', 1.0)
+                    if move_kwargs.pop('gamma0_mode', None) == 'auto':
+                        move_kwargs['gamma0'] = None
+
+                    this_move_obj = getattr(emcee.moves, '{}Move'.format(move_class))(**move_kwargs)
+
+                    logger.info("creating {}Move(**{}) with weight={}".format(move_class, move_kwargs, move_weight))
+                    moves.append((this_move_obj, move_weight))
+
+                esargs['moves'] = moves
 
             esargs['kwargs'] = {'b': _bsolver(b, solver, compute, init_from+priors, wrap_central_values),
                                 'params_uniqueids': params_uniqueids,

--- a/tests/tests/test_forbidden_labels/test_forbidden_parameters.py
+++ b/tests/tests/test_forbidden_labels/test_forbidden_parameters.py
@@ -31,10 +31,11 @@ def test_forbidden(verbose=False):
     b.add_solver('optimizer.differential_corrections')
     b.add_solver('optimizer.cg')
     b.add_solver('optimizer.powell')
-    b.add_solver('sampler.emcee')
+    b.add_solver('sampler.emcee', solver='emcee_solv')
     b.add_solver('sampler.dynesty')
 
     b.add_server('remoteslurm')
+    b.add_server('localthread')
 
     # TODO: include constraint_func?  Shouldn't matter since they're not in twigs
     should_be_forbidden = b.qualifiers + b.contexts + b.kinds + [c.split('@')[0] for c in b.get_parameter(qualifier='columns').choices]


### PR DESCRIPTION
This implements the ability to override the move within the emcee sampler backend via a feature but has not been tested.

To use:
```
import phoebe

b = phoebe.default_binary()
...
b.add_solver('emcee', solver='emcee01')
b.add_feature('emcee_move', solver='emcee01', feature='move01')
print(b.filter(feature='move01'))
```

TODO:
- [ ] test to see if this works and is actually useful to have in the code
- [ ] documentation
- [ ] test coverage