### PR TITLE
Updated functionality for lnf_rv

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -4615,6 +4615,13 @@ class Bundle(ParameterSet):
                                             +addl_parameters,
                                             True, 'run_solver')
 
+                # this check can/should be removed in PHOEBE 2.5
+                for param in self.filter(qualifier='sigmas_lnf', dataset=rv_datasets, context='dataset', **_skip_filter_checks).to_list():
+                    if np.isfinite(param.get_value()):
+                        report.add_item(self,
+                                        "behavior of sigmas_lnf for RVs was changed (fixed) in PHOEBE 2.4.15 to be independent of the RV value.  See https://github.com/phoebe-project/phoebe2/pull/901",
+                                        [param]+addl_parameters,
+                                        False, 'run_solver')
 
 
             if 'lc_datasets' in solver_ps.qualifiers:

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3854,11 +3854,16 @@ class ParameterSet(object):
                         sigmas = sigmas[inds]
 
                 sigmas_lnf = ds_ps.get_value(qualifier='sigmas_lnf', component=ds_comp, default=-np.inf, **_skip_filter_checks)
+                dataset_kind = ds_ps.kind
 
                 if len(sigmas):
                     sigmas2 = sigmas**2
+                    
                     if cf == 'lnf' and sigmas_lnf != -np.inf:
-                        sigmas2 += model_interp.value**2 * np.exp(2 * sigmas_lnf)
+                        if dataset_kind == 'rv':
+                            sigmas2 += np.exp(2 * sigmas_lnf)
+                        else:
+                            sigmas2 += model_interp.value**2 * np.exp(2 * sigmas_lnf)
 
                     if cf == 'lnf':
                         ret += np.sum((residuals.value**2 / sigmas2) + np.log(2*np.pi*sigmas2))


### PR DESCRIPTION
Updated _calculate_cf function to adjust lnf calculation for radial velocities. The noise nuisance parameter for rvs no longer contains the rv amplitude.  

Closes #752 and #895

TODO:
- [ ] update documentation to mention change (and remove in release-2.5 branch)
- [x] add warning when using lnf with rv to mention change in behavior (and remove in release-2.5 branch)