### PR TITLE
Updates to accommodate ndpolator 1.2.1.

### DIFF
--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -880,18 +880,22 @@ class Passband:
         ints_energy, ints_photon = np.empty(nmodels*len(mus)), np.empty(nmodels*len(mus))
 
         if include_extinction:
-            if rvs is None:
-                rvs = np.linspace(2., 6., 16)
             if ebvs is None:
                 ebvs = np.linspace(0., 3., 30)
+            if rvs is None:
+                rvs = np.linspace(2., 6., 16)
 
-            ebv_list = np.tile(np.repeat(ebvs, len(rvs)), nmodels)
-            rv_list = np.tile(rvs, nmodels*len(ebvs))
+            ext_axes = (np.unique(teffs), np.unique(loggs), np.unique(abuns), ebvs, rvs)
+            ext_photon_grid = np.empty(shape=(len(np.unique(teffs)), len(np.unique(loggs)), len(np.unique(abuns)), len(ebvs), len(rvs), 1))
+            ext_energy_grid = np.empty(shape=(len(np.unique(teffs)), len(np.unique(loggs)), len(np.unique(abuns)), len(ebvs), len(rvs), 1))
 
-            ext_matrix = np.rollaxis(np.array([np.split(rv_list*ebv_list, nmodels), np.split(ebv_list, nmodels)]), 1)
-            ext_matrix = np.ascontiguousarray(ext_matrix)
+            # ebv_list = np.tile(np.repeat(ebvs, len(rvs)), nmodels)
+            # rv_list = np.tile(rvs, nmodels*len(ebvs))
 
-            ext_energy, ext_photon = np.empty((nmodels, len(rvs)*len(ebvs))), np.empty((nmodels, len(rvs)*len(ebvs)))
+            # ext_matrix = np.rollaxis(np.array([np.split(rv_list*ebv_list, nmodels), np.split(ebv_list, nmodels)]), 1)
+            # ext_matrix = np.ascontiguousarray(ext_matrix)
+
+            # ext_energy, ext_photon = np.empty((nmodels, len(rvs)*len(ebvs))), np.empty((nmodels, len(rvs)*len(ebvs)))
 
         keep = (wls >= self.ptf_table['wl'][0]) & (wls <= self.ptf_table['wl'][-1])
         wls = wls[keep]
@@ -916,9 +920,19 @@ class Passband:
                 ints_photon[i*len(mus):(i+1)*len(mus)] = np.log10(fluxes_photon/self.ptf_photon_area)  # photon-weighted intensity
 
                 if include_extinction:
-                    ext_lambda = np.matmul(libphoebe.gordon_extinction(wls), ext_matrix[i])
-                    flux_frac = np.exp(-0.9210340371976184*ext_lambda)  #10**(-0.4*ext_lambda)
-                    ext_energy[i], ext_photon[i] = np.dot([pbints_energy[-1]/fluxes_energy[-1], pbints_photon[-1]/fluxes_photon[-1]], flux_frac)
+                    axbx = libphoebe.gordon_extinction(wls)
+                    ax, bx = axbx[:,0], axbx[:,1]
+                    for ei, ebv in enumerate(ebvs):
+                        for ri, rv in enumerate(rvs):
+                            Alam=10**(-0.4 * ebv * (rv * ax + bx))
+                            t = (teffs[i] == ext_axes[0], loggs[i] == ext_axes[1], abuns[i] == ext_axes[2], ebvs[ei] == ext_axes[3], rvs[ri] == ext_axes[4],0)
+                            ext_energy_grid[t] = np.trapz(self.ptf(wls) * seds * Alam, wls)[-1] / np.trapz(self.ptf(wls) * seds, wls)[-1]
+                            ext_photon_grid[t] = np.trapz(wls * self.ptf(wls) * seds * Alam, wls)[-1] / np.trapz(wls * self.ptf(wls) * seds, wls)[-1]
+
+
+                    # ext_lambda = np.matmul(libphoebe.gordon_extinction(wls), ext_matrix[i])
+                    # flux_frac = np.exp(-0.9210340371976184*ext_lambda)  #10**(-0.4*ext_lambda)
+                    # ext_energy[i], ext_photon[i] = np.dot([pbints_energy[-1]/fluxes_energy[-1], pbints_photon[-1]/fluxes_photon[-1]], flux_frac)
 
         basic_axes = (np.unique(teffs), np.unique(loggs), np.unique(abuns))
         self.ndp[atm] = ndpolator.Ndpolator(basic_axes=basic_axes)
@@ -946,23 +960,26 @@ class Passband:
             associated_axes = (np.unique(ebvs), np.unique(rvs))
             axes = basic_axes + associated_axes
 
-            teffs = np.repeat(teffs, len(ebvs)*len(rvs))
-            loggs = np.repeat(loggs, len(ebvs)*len(rvs))
-            abuns = np.repeat(abuns, len(ebvs)*len(rvs))
-
-            ext_energy_grid = np.full(shape=[len(axis) for axis in axes]+[1], fill_value=np.nan)
-            ext_photon_grid = np.copy(ext_energy_grid)
-
-            flat_energy = ext_energy.flat
-            flat_photon = ext_photon.flat
-
-            for i in range(nmodels*len(ebvs)*len(rvs)):
-                t = (teffs[i] == axes[0], loggs[i] == axes[1], abuns[i] == axes[2], ebv_list[i] == axes[3], rv_list[i] == axes[4], 0)
-                ext_energy_grid[t] = flat_energy[i]
-                ext_photon_grid[t] = flat_photon[i]
-
             self.ndp[atm].register('ext@photon', associated_axes, ext_photon_grid)
             self.ndp[atm].register('ext@energy', associated_axes, ext_energy_grid)
+
+            # teffs = np.repeat(teffs, len(ebvs)*len(rvs))
+            # loggs = np.repeat(loggs, len(ebvs)*len(rvs))
+            # abuns = np.repeat(abuns, len(ebvs)*len(rvs))
+
+            # ext_energy_grid = np.full(shape=[len(axis) for axis in axes]+[1], fill_value=np.nan)
+            # ext_photon_grid = np.copy(ext_energy_grid)
+
+            # flat_energy = ext_energy.flat
+            # flat_photon = ext_photon.flat
+
+            # for i in range(nmodels*len(ebvs)*len(rvs)):
+            #     t = (teffs[i] == axes[0], loggs[i] == axes[1], abuns[i] == axes[2], ebv_list[i] == axes[3], rv_list[i] == axes[4])
+            #     ext_energy_grid[t] = flat_energy[i]
+            #     ext_photon_grid[t] = flat_photon[i]
+
+            # self.ndp[atm].register('ext@photon', associated_axes, ext_photon_grid)
+            # self.ndp[atm].register('ext@energy', associated_axes, ext_energy_grid)
 
             if f'{atm}:ext' not in self.content:
                 self.content.append(f'{atm}:ext')

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -1397,7 +1397,7 @@ class Passband:
 
         return log10_Inorm
 
-    def Inorm(self, query_pts, atm='ck2004', ldatm='ck2004', ldint=None, ld_func='interp', ld_coeffs=None, intens_weighting='photon', atm_extrapolation_method='none', ld_extrapolation_method='none', blending_method='none', return_nanmask=False):
+    def Inorm(self, query_pts, atm='ck2004', ldatm='ck2004', ldint=None, ld_func='interp', ld_coeffs=None, intens_weighting='photon', atm_extrapolation_method='none', ld_extrapolation_method='none', blending_method='none', dist_threshold=1e-5):
         r"""
         Computes normal emergent passband intensity.
 

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -1498,8 +1498,10 @@ class Passband:
 
             if intens_weighting == 'photon':
                 intensities = 10**self._log10_Inorm_bb_photon(query_pts[:,0])
-            else:  # if intens_weighting == 'energy':
+            elif intens_weighting == 'energy':
                 intensities = 10**self._log10_Inorm_bb_energy(query_pts[:,0])
+            else:
+                raise ValueError(f'{intens_weighting=} not recognized, must be "photon" or "energy".')
 
             if ldint is None:
                 if ld_func != 'interp' and ld_coeffs is None:

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -1685,9 +1685,11 @@ class Passband:
             raise ValueError(f'ldatm={ldatm} is not supported.')
 
         if ld_func == 'interp':
-            if 'atm' == 'blackbody' and 'blackbody:Inorm' in self.content and ldatm in ['ck2004', 'phoenix', 'tmap_sdO', 'tmap_DA', 'tmap_DAO', 'tmap_DO']:
+            if atm == 'blackbody' and 'blackbody:Inorm' in self.content and ldatm in ['ck2004', 'phoenix', 'tmap_sdO', 'tmap_DA', 'tmap_DAO', 'tmap_DO']:
                 # we need to apply ldatm's limb darkening to blackbody intensities:
                 #   Imu^bb = Lmu Inorm^bb = Imu^atm / Inorm^atm * Inorm^bb
+
+                # print(f'{atm=} {ld_func=} {ldatm=} {intens_weighting=} {query_pts=} {atm_extrapolation_method=}')
 
                 ndpolants = self.ndp[ldatm].ndpolate(f'imu@{intens_weighting}', query_pts, extrapolation_method=atm_extrapolation_method)
                 log10imus_atm = ndpolants['interps']
@@ -1752,7 +1754,7 @@ class Passband:
                         atm_extrapolation_method=atm_extrapolation_method,
                         ld_extrapolation_method=ld_extrapolation_method
                     )
-                    log10imus_bb = np.log10(ints_bb['inorms'])
+                    log10imus_bb = np.log10(ints_bb)
 
                     log10imus_blended = log10imus_atm.copy()
                     log10imus_blended[off_grid] = (np.minimum(dists[off_grid], blending_margin) * log10imus_bb + np.maximum(blending_margin-dists[off_grid], 0) * log10imus_atm[off_grid])/blending_margin

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -889,14 +889,6 @@ class Passband:
             ext_photon_grid = np.empty(shape=(len(np.unique(teffs)), len(np.unique(loggs)), len(np.unique(abuns)), len(ebvs), len(rvs), 1))
             ext_energy_grid = np.empty(shape=(len(np.unique(teffs)), len(np.unique(loggs)), len(np.unique(abuns)), len(ebvs), len(rvs), 1))
 
-            # ebv_list = np.tile(np.repeat(ebvs, len(rvs)), nmodels)
-            # rv_list = np.tile(rvs, nmodels*len(ebvs))
-
-            # ext_matrix = np.rollaxis(np.array([np.split(rv_list*ebv_list, nmodels), np.split(ebv_list, nmodels)]), 1)
-            # ext_matrix = np.ascontiguousarray(ext_matrix)
-
-            # ext_energy, ext_photon = np.empty((nmodels, len(rvs)*len(ebvs))), np.empty((nmodels, len(rvs)*len(ebvs)))
-
         keep = (wls >= self.ptf_table['wl'][0]) & (wls <= self.ptf_table['wl'][-1])
         wls = wls[keep]
 
@@ -924,15 +916,10 @@ class Passband:
                     ax, bx = axbx[:,0], axbx[:,1]
                     for ei, ebv in enumerate(ebvs):
                         for ri, rv in enumerate(rvs):
-                            Alam=10**(-0.4 * ebv * (rv * ax + bx))
+                            Alam = 10**(-0.4 * ebv * (rv * ax + bx))
                             t = (teffs[i] == ext_axes[0], loggs[i] == ext_axes[1], abuns[i] == ext_axes[2], ebvs[ei] == ext_axes[3], rvs[ri] == ext_axes[4],0)
                             ext_energy_grid[t] = np.trapz(self.ptf(wls) * seds * Alam, wls)[-1] / np.trapz(self.ptf(wls) * seds, wls)[-1]
                             ext_photon_grid[t] = np.trapz(wls * self.ptf(wls) * seds * Alam, wls)[-1] / np.trapz(wls * self.ptf(wls) * seds, wls)[-1]
-
-
-                    # ext_lambda = np.matmul(libphoebe.gordon_extinction(wls), ext_matrix[i])
-                    # flux_frac = np.exp(-0.9210340371976184*ext_lambda)  #10**(-0.4*ext_lambda)
-                    # ext_energy[i], ext_photon[i] = np.dot([pbints_energy[-1]/fluxes_energy[-1], pbints_photon[-1]/fluxes_photon[-1]], flux_frac)
 
         basic_axes = (np.unique(teffs), np.unique(loggs), np.unique(abuns))
         self.ndp[atm] = ndpolator.Ndpolator(basic_axes=basic_axes)
@@ -962,24 +949,6 @@ class Passband:
 
             self.ndp[atm].register('ext@photon', associated_axes, ext_photon_grid)
             self.ndp[atm].register('ext@energy', associated_axes, ext_energy_grid)
-
-            # teffs = np.repeat(teffs, len(ebvs)*len(rvs))
-            # loggs = np.repeat(loggs, len(ebvs)*len(rvs))
-            # abuns = np.repeat(abuns, len(ebvs)*len(rvs))
-
-            # ext_energy_grid = np.full(shape=[len(axis) for axis in axes]+[1], fill_value=np.nan)
-            # ext_photon_grid = np.copy(ext_energy_grid)
-
-            # flat_energy = ext_energy.flat
-            # flat_photon = ext_photon.flat
-
-            # for i in range(nmodels*len(ebvs)*len(rvs)):
-            #     t = (teffs[i] == axes[0], loggs[i] == axes[1], abuns[i] == axes[2], ebv_list[i] == axes[3], rv_list[i] == axes[4])
-            #     ext_energy_grid[t] = flat_energy[i]
-            #     ext_photon_grid[t] = flat_photon[i]
-
-            # self.ndp[atm].register('ext@photon', associated_axes, ext_photon_grid)
-            # self.ndp[atm].register('ext@energy', associated_axes, ext_energy_grid)
 
             if f'{atm}:ext' not in self.content:
                 self.content.append(f'{atm}:ext')

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -1484,6 +1484,7 @@ class Passband:
         #     raise ValueError(f'blending_method={blending_method} is not supported.')
 
         raise_on_nans = True if atm_extrapolation_method == 'none' else False
+        blending_factors = None
 
         if atm == 'blackbody' and 'blackbody:Inorm' in self.content:
             # check if the required tables for the chosen ldatm are available:
@@ -1556,14 +1557,16 @@ class Passband:
 
                 log10ints_blended = log10ints.copy()
                 log10ints_blended[off_grid] = (np.minimum(dists[off_grid], blending_margin) * log10ints_bb[off_grid] + np.maximum(blending_margin-dists[off_grid], 0) * log10ints[off_grid])/blending_margin
+                blending_factors = np.minimum(dists, blending_margin)/blending_margin
 
                 intensities = 10**log10ints_blended
             else:
                 intensities = 10**log10ints
 
         ints = {
-            'inorms': intensities
-            # TODO: add other dict keys!
+            'inorms': intensities,
+            'bfs': blending_factors,
+            # TODO: add any other dict keys?
         }
 
         return ints

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1890,9 +1890,6 @@ class Star(Body):
                 blending_method=blending_method
             )
 
-            # if abs_intensities is None or not np.all(np.isfinite(abs_intensities)):
-            #     print(f'{query_pts.shape=} {atm=} {ldatm=} {ldint.shape=} {ld_func=} {ld_coeffs=} {intens_weighting=}')
-
             # Beaming/boosting
             if boosting_method == 'none' or ignore_effects:
                 boost_factors = 1.0

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1852,7 +1852,7 @@ class Star(Body):
                 intens_weighting=intens_weighting,
                 ld_extrapolation_method=ld_extrapolation_method,
                 raise_on_nans=True
-            ).flatten()
+            )
 
             abs_normal_intensities = pb.Inorm(
                 query_pts=query_pts,
@@ -1865,7 +1865,7 @@ class Star(Body):
                 atm_extrapolation_method=atm_extrapolation_method,
                 ld_extrapolation_method=ld_extrapolation_method,
                 blending_method=blending_method
-            ).flatten()
+            )['inorms']
 
             if atm == 'blackbody' and extinct > 0:
                 query_pts = np.stack((
@@ -1897,8 +1897,10 @@ class Star(Body):
                 atm_extrapolation_method=atm_extrapolation_method,
                 ld_extrapolation_method=ld_extrapolation_method,
                 blending_method=blending_method
-            ).flatten()
+            )
 
+            # if abs_intensities is None or not np.all(np.isfinite(abs_intensities)):
+            #     print(f'{query_pts.shape=} {atm=} {ldatm=} {ldint.shape=} {ld_func=} {ld_coeffs=} {intens_weighting=}')
 
             # Beaming/boosting
             if boosting_method == 'none' or ignore_effects:
@@ -1923,7 +1925,7 @@ class Star(Body):
                     atm=atm,
                     intens_weighting=intens_weighting,
                     extrapolation_method=atm_extrapolation_method
-                ).flatten()
+                )
 
                 # extinction is NOT aspect dependent, so we'll correct both
                 # normal and directional intensities
@@ -1947,11 +1949,11 @@ class Star(Body):
 
         # TODO: do we really need to store all of these if store_mesh==False?
         # Can we optimize by only returning the essentials if we know we don't need them?
-        return {'abs_normal_intensities': abs_normal_intensities,
-                'normal_intensities': normal_intensities,
-                'abs_intensities': abs_intensities,
-                'intensities': intensities,
-                'ldint': ldint,
+        return {'abs_normal_intensities': abs_normal_intensities.flatten(),
+                'normal_intensities': normal_intensities.flatten(),
+                'abs_intensities': abs_intensities.flatten(),
+                'intensities': intensities.flatten(),
+                'ldint': ldint.flatten(),
                 'boost_factors': boost_factors}
 
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10742,7 +10742,6 @@ class Bundle(ParameterSet):
                         continue
 
                     pblums_abs[dataset][component] = float(star.compute_luminosity(dataset, scaled=False))
-                    # print(f'{pblums_abs[dataset][component]=}')
 
             elif pblum_method == 'stefan-boltzmann':
                 for component in valid_components:
@@ -10787,7 +10786,6 @@ class Bundle(ParameterSet):
                         ld_extrapolation_method=ld_extrapolation_method,
                         blending_method=blending_method
                     )['inorms']
-                    # print(f'compute_pblums: {abs_normal_intensities=}')
 
                     ldint = pb.ldint(
                         query_pts=query_pts,
@@ -10798,7 +10796,6 @@ class Bundle(ParameterSet):
                         ld_extrapolation_method=ld_extrapolation_method,
                         raise_on_nans=True
                     )
-                    # print(f'compute_pblums: {ldint=}')
 
                     if intens_weighting=='photon':
                         ptfarea = pb.ptf_photon_area/pb.h/pb.c

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -10785,9 +10785,8 @@ class Bundle(ParameterSet):
                         intens_weighting=intens_weighting,
                         atm_extrapolation_method=atm_extrapolation_method,
                         ld_extrapolation_method=ld_extrapolation_method,
-                        blending_method=blending_method,
-                        return_nanmask=False
-                    ).flatten()
+                        blending_method=blending_method
+                    )['inorms']
                     # print(f'compute_pblums: {abs_normal_intensities=}')
 
                     ldint = pb.ldint(
@@ -10798,7 +10797,7 @@ class Bundle(ParameterSet):
                         intens_weighting=intens_weighting,
                         ld_extrapolation_method=ld_extrapolation_method,
                         raise_on_nans=True
-                    ).flatten()
+                    )
                     # print(f'compute_pblums: {ldint=}')
 
                     if intens_weighting=='photon':
@@ -10808,7 +10807,8 @@ class Bundle(ParameterSet):
 
                     logger.info("estimating pblum for {}@{} using atm='{}' and stefan-boltzmann approximation".format(dataset, component, atm))
                     # requiv in m, Inorm in W/m**3, ldint unitless, ptfarea in m -> pblum_abs in W
-                    pblums_abs[dataset][component] = float(4 * np.pi * requivs[component]**2 * abs_normal_intensities * ldint * ptfarea)
+                    pblum = 4 * np.pi * requivs[component]**2 * abs_normal_intensities * ldint * ptfarea
+                    pblums_abs[dataset][component] = pblum[0,0]
 
             else:
                 raise ValueError("pblum_method='{}' not supported".format(pblum_method))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     "scipy",
     "astropy",
     "pytest",
-    "ndpolator == 1.2",
+    "ndpolator == 1.2.1",
     "tqdm",
     "corner",
     "requests",

--- a/tests/tests/test_distance/test_distance.py
+++ b/tests/tests/test_distance/test_distance.py
@@ -28,7 +28,8 @@ def test_distance_scaling_alt_backend(verbose=False, plot=False):
         b.plot(legend=True, show=True)
 
     for model in b.models:
-        diff = abs(0.5-b.get_value(qualifier='fluxes', model=model)[0])
+        flux = b.get_value(qualifier='fluxes', model=model)[0]
+        diff = abs(0.5-flux)
         if verbose:
             print(f"model={model} diff={diff}")
         assert diff < 0.01

--- a/tests/tests/test_extinction/test_bb_extinction.py
+++ b/tests/tests/test_extinction/test_bb_extinction.py
@@ -37,7 +37,7 @@ def test_bb_extinction():
     Alam = 10**(-0.4 * ebvs * (rvs * ax + bx))  # (101, 11)
     iext_predicted = np.trapz(bb_sed * Alam, axis=0) / np.trapz(bb_sed, axis=0)
 
-    query_pts = np.vstack((teffs, rvs, ebvs)).T
+    query_pts = np.vstack((teffs, ebvs, rvs)).T
     iext = pb.interpolate_extinct(query_pts=query_pts, atm='blackbody', intens_weighting='photon', extrapolation_method='none').flatten()
 
     assert np.allclose(iext, iext_predicted, atol=2e-3, rtol=2e-3)
@@ -62,7 +62,7 @@ def test_frontend():
     b.flip_constraint('ebv', solve_for='Av')
     b['Rv'] = 3.1
     b['ebv'] = 0.3
-    b.run_compute(model='lc_ext')
+    b.run_compute(model='lc_ext', irrad_method='none')
 
     assert np.mean(b['value@fluxes@lc_ext']/b['value@fluxes@lc_no_ext'])-0.785 < 1e-3
 

--- a/tests/tests/test_extinction/test_bb_extinction.py
+++ b/tests/tests/test_extinction/test_bb_extinction.py
@@ -68,3 +68,9 @@ def test_frontend():
 
     phoebe.uninstall_passband('box:test')
     os.remove('box_test.fits')
+
+
+if __name__ == '__main__':
+    test_bb_extinction_computation()
+    test_bb_extinction()
+    test_frontend()


### PR DESCRIPTION
The code has also been further simplified and debugged, and several deprecations have been handled. For the time being, numpy <2.0 is imposed until all tests are run adequately.