### PR TITLE
Adding back the definition of self.wl to passband load() function

### DIFF
--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -433,6 +433,7 @@ class Passband:
             self.pbname = header['pbname']
             self.effwl = header['effwl']
             self.calibrated = header['calibrtd']
+            self.wl_oversampling = header.get('wlovsmpl', 1)
             self.comments = header['comments']
             self.reference = header['referenc']
             self.ptf_order = header['ptforder']
@@ -449,6 +450,7 @@ class Passband:
             self.history = {h.split(': ')[0]: ': '.join(h.split(': ')[1:]) for h in history if len(h.split(': ')) > 1}
 
             self.ptf_table = hdul['ptftable'].data
+            self.wl = np.linspace(self.ptf_table['wl'][0], self.ptf_table['wl'][-1], int(self.wl_oversampling*len(self.ptf_table['wl'])))
 
             # Rebuild ptf() and photon_ptf() functions:
             self.ptf_func = interpolate.splrep(self.ptf_table['wl'], self.ptf_table['fl'], s=0, k=self.ptf_order)


### PR DESCRIPTION
At some point (I haven't managed to track down when), the definition of self.wl disappeared from the passband load() function. This means that already created passbands cannot be built upon and needed to be initialised from scratch, i.e.
```python
pb=phoebe.get_passband("Johnson:V")
pb.compute_blackbody_response()
```
will fail, even though the passband includes all the required information to recalculate the blackbody response.