### PR TITLE
Re-added script installs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,7 @@ packages = [
     "phoebe.dependencies.ligeor.models",
     "phoebe.dependencies.ligeor.utils",
 ]
+script-files = [
+    "client-server/phoebe-server",
+    "client-server/phoebe-autofig",
+]


### PR DESCRIPTION
During the setup.py->pyproject.toml transition in 2.4.12, installing phoebe-server and phoebe-autofig scripts was inadvertently removed. It has now been reintroduced to pyproject.toml.