### PR TITLE
Correction of residuals for interferometry

### DIFF
--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3804,7 +3804,7 @@ class ParameterSet(object):
             raise ValueError("model and dataset do not have the same default_unit, cannot interpolate")
 
         # no interpolation for interferometry
-        if qualifier in ['vises', 'clos', 't3s']:
+        if dataset_kind in ['vis', 'clo', 't3']:
             model_interp = model_param.value
             residuals = dataset_param.value - model_param.value
         else:

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3803,8 +3803,13 @@ class ParameterSet(object):
         if dataset_param.default_unit != model_param.default_unit:
             raise ValueError("model and dataset do not have the same default_unit, cannot interpolate")
 
-        model_interp = model_param.interp_value(times=times, consider_gaussian_process=consider_gaussian_process)
-        residuals = np.asarray(dataset_param.interp_value(times=times, consider_gaussian_process=consider_gaussian_process) - model_interp)
+        # no interpolation for interferometry
+        if qualifier in ['vises', 'clos', 't3s']:
+            model_interp = model_param.value
+            residuals = dataset_param.value - model_param.value
+        else:
+            model_interp = model_param.interp_value(times=times, consider_gaussian_process=consider_gaussian_process)
+            residuals = np.asarray(dataset_param.interp_value(times=times, consider_gaussian_process=consider_gaussian_process) - model_interp)
 
         if as_quantity:
             if return_interp_model:


### PR DESCRIPTION
The reason is that one cannot interpolate in time (many u, v, vis measurements are for the same time).