### PR TITLE
Support for numpy 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
     "Topic :: Software Development :: User Interfaces"
 ]
 dependencies = [
-    "numpy < 2.0.0",
+    "numpy",
     "scipy",
     "astropy",
     "pytest",
@@ -79,7 +79,7 @@ repository = "https://github.com/phoebe-project/phoebe2"
 documentation = "http://phoebe-project.org/docs"
 
 [build-system]
-requires = ["setuptools", "numpy < 2.0.0", "wheel"]
+requires = ["setuptools", "numpy", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This currently just reverts the max-pin to expose logs and to use for testing changes needed to re-introduce support for numpy 2.0.