### PR TITLE
Correction of constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ CHANGELOG
 * sigmas_lnf: change handling of noise-nuissance parameter for RVs to no longer depend on the RV amplitude. [#901]
 * Remove duplicated phoebe-server code. [#940]
 * Fix python 3.12+ support by updating invalid escape sequences. [#948]
+* Improved precision in calculation of constraints. [#945]
 
 ### 2.4.14
 

--- a/phoebe/frontend/default_bundles/default_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_binary.bundle
@@ -144,7 +144,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (maximum) value of the equivalent radius for the given morphology",
-"value": 2.013275176537638,
+"value": 2.0132751765376384,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -426,8 +426,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"ck2004",
-"phoenix"
+"phoenix",
+"ck2004"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -492,7 +492,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (maximum) value of the equivalent radius for the given morphology",
-"value": 2.013275176537638,
+"value": 2.0132751765376384,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -774,8 +774,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"ck2004",
-"phoenix"
+"phoenix",
+"ck2004"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -2099,11 +2099,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": {
@@ -2304,11 +2304,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2322,11 +2322,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2522,7 +2522,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.11.dev+feature-interferometry",
+"value": "2.4.15",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_binary.bundle
@@ -209,7 +209,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "logg at requiv",
-"value": 4.437551877570185,
+"value": 4.437551868254479,
 "default_unit": "",
 "limits": [
 null,
@@ -259,7 +259,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Rotation frequency (wrt the sky)",
-"value": 6.283185,
+"value": 6.283185307179586,
 "default_unit": "rad / d",
 "limits": [
 0.0,
@@ -426,8 +426,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"phoenix",
-"ck2004"
+"ck2004",
+"phoenix"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -460,7 +460,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Mass",
-"value": 0.9988131358058301,
+"value": 0.9988131257959815,
 "default_unit": "solMass",
 "limits": [
 1e-12,
@@ -557,7 +557,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "logg at requiv",
-"value": 4.437551877570185,
+"value": 4.437551868254479,
 "default_unit": "",
 "limits": [
 null,
@@ -607,7 +607,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Rotation frequency (wrt the sky)",
-"value": 6.283185,
+"value": 6.283185307179586,
 "default_unit": "rad / d",
 "limits": [
 0.0,
@@ -774,8 +774,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"phoenix",
-"ck2004"
+"ck2004",
+"phoenix"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -808,7 +808,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Mass",
-"value": 0.9988131358058301,
+"value": 0.9988131257959815,
 "default_unit": "solMass",
 "limits": [
 1e-12,
@@ -857,7 +857,7 @@ null
 "kind": "orbit",
 "context": "component",
 "description": "Orbital frequency (sidereal)",
-"value": 6.283185,
+"value": 6.283185307179586,
 "default_unit": "rad / d",
 "limits": [
 null,
@@ -988,7 +988,7 @@ null
 "kind": "orbit",
 "context": "component",
 "description": "Mean anomaly at t0@system",
-"value": 89.99999559997653,
+"value": 90.0,
 "default_unit": "deg",
 "limits": [
 null,
@@ -1245,7 +1245,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@primary@component}",
+"value": "6.28318530717958623e+00 / {period@primary@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -1261,7 +1261,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "log10((({mass@primary@component} / ({requiv@primary@component} ** 2.000000)) * 2942.206218) * 9.319541)",
+"value": "log10((({mass@primary@component} / ({requiv@primary@component} ** 2.000000)) * 2.94220621750441933e+03) * 9.31954089506172778e+00)",
 "default_unit": "",
 "constraint_func": "logg",
 "constraint_kwargs": {
@@ -1277,7 +1277,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "1.000000 - {irrad_frac_refl_bol@primary@component}",
+"value": "1.00000000000000000e+00 - {irrad_frac_refl_bol@primary@component}",
 "default_unit": "",
 "constraint_func": "irrad_frac",
 "constraint_kwargs": {
@@ -1293,7 +1293,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@secondary@component}",
+"value": "6.28318530717958623e+00 / {period@secondary@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -1309,7 +1309,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "log10((({mass@secondary@component} / ({requiv@secondary@component} ** 2.000000)) * 2942.206218) * 9.319541)",
+"value": "log10((({mass@secondary@component} / ({requiv@secondary@component} ** 2.000000)) * 2.94220621750441933e+03) * 9.31954089506172778e+00)",
 "default_unit": "",
 "constraint_func": "logg",
 "constraint_kwargs": {
@@ -1325,7 +1325,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "1.000000 - {irrad_frac_refl_bol@secondary@component}",
+"value": "1.00000000000000000e+00 - {irrad_frac_refl_bol@secondary@component}",
 "default_unit": "",
 "constraint_func": "irrad_frac",
 "constraint_kwargs": {
@@ -1389,7 +1389,7 @@ null
 "kind": "orbit",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "{period@binary@component} / ((((-1.000000 * {period@binary@component}) * {dperdt@binary@component}) / 6.283185307179586231995926937088) + 1.000000000000000000000000000000)",
+"value": "{period@binary@component} / ((((-1.00000000000000000e+00 * {period@binary@component}) * {dperdt@binary@component}) / 6.28318530717958623e+00) + 1.00000000000000000e+00)",
 "default_unit": "d",
 "constraint_func": "period_anom",
 "constraint_kwargs": {
@@ -1405,7 +1405,7 @@ null
 "kind": "orbit",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "(6.283185 * ({t0@system} - {t0_perpass@binary@component})) / {period@binary@component}",
+"value": "(6.28318530717958623e+00 * ({t0@system} - {t0_perpass@binary@component})) / {period@binary@component}",
 "default_unit": "deg",
 "constraint_func": "mean_anom",
 "constraint_kwargs": {
@@ -1463,7 +1463,7 @@ null
 "kind": "orbit",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@binary@component}",
+"value": "6.28318530717958623e+00 / {period@binary@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -1539,7 +1539,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "(39.478418 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ({q@binary@component} + 1.000000)) * 2942.206217504419328179210424423218)",
+"value": "(3.94784176043574320e+01 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ({q@binary@component} + 1.000000)) * 2.94220621750441933e+03)",
 "default_unit": "solMass",
 "constraint_func": "mass",
 "constraint_kwargs": {
@@ -1561,7 +1561,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "{sma@binary@component} / ((1.000000 / {q@binary@component}) + 1.000000)",
+"value": "{sma@binary@component} / ((1.00000000000000000e+00 / {q@binary@component}) + 1.00000000000000000e+00)",
 "default_unit": "solRad",
 "constraint_func": "comp_sma",
 "constraint_kwargs": {
@@ -1577,7 +1577,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "({sma@binary@component} * (sin({incl@binary@component}))) / ((1.000000 / {q@binary@component}) + 1.000000)",
+"value": "({sma@binary@component} * (sin({incl@binary@component}))) / ((1.00000000000000000e+00 / {q@binary@component}) + 1.00000000000000000e+00)",
 "default_unit": "solRad",
 "constraint_func": "comp_asini",
 "constraint_kwargs": {
@@ -1657,7 +1657,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "(39.478418 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ((1.000000 / {q@binary@component}) + 1.000000)) * 2942.206217504419328179210424423218)",
+"value": "(3.94784176043574320e+01 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ((1.00000000000000000e+00 / {q@binary@component}) + 1.00000000000000000e+00)) * 2.94220621750441933e+03)",
 "default_unit": "solMass",
 "constraint_func": "mass",
 "constraint_kwargs": {
@@ -2099,11 +2099,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": {
@@ -2304,11 +2304,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2322,11 +2322,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2522,7 +2522,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.6",
+"value": "2.4.11.dev+feature-interferometry",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_contact_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_contact_binary.bundle
@@ -144,7 +144,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (maximum) value of the equivalent radius for the given morphology",
-"value": 1.6724563972838384,
+"value": 1.6724563972838287,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -160,7 +160,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (minimum) value of the equivalent radius for the given morphology",
-"value": 1.2725418568681297,
+"value": 1.27254185686813,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -426,8 +426,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"ck2004",
-"phoenix"
+"phoenix",
+"ck2004"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -476,7 +476,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Equivalent radius",
-"value": 1.4999999999999996,
+"value": 1.5000000000000122,
 "default_unit": "solRad",
 "limits": [
 1e-06,
@@ -492,7 +492,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (maximum) value of the equivalent radius for the given morphology",
-"value": 1.6724563972838378,
+"value": 1.672456397283698,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -508,7 +508,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (minimum) value of the equivalent radius for the given morphology",
-"value": 1.2725418568681297,
+"value": 1.27254185686813,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -557,7 +557,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "logg at requiv",
-"value": 4.089736153779248,
+"value": 4.08973615377924,
 "default_unit": "",
 "limits": [
 null,
@@ -774,8 +774,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"ck2004",
-"phoenix"
+"phoenix",
+"ck2004"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -1131,7 +1131,7 @@ null
 "kind": "envelope",
 "context": "component",
 "description": "Fillout-factor of the envelope",
-"value": 0.6417897080770951,
+"value": 0.6417897080770861,
 "default_unit": "",
 "limits": [
 0.0,
@@ -1147,7 +1147,7 @@ null
 "kind": "envelope",
 "context": "component",
 "description": "Potential of the envelope (from the primary component's reference)",
-"value": 3.4013774072298766,
+"value": 3.4013774072298815,
 "default_unit": "",
 "limits": [
 0.0,
@@ -1211,7 +1211,7 @@ null
 "kind": "orbit",
 "context": "component",
 "description": "ratio between equivalent radii of children stars",
-"value": 0.9999999999999997,
+"value": 1.0000000000000082,
 "default_unit": "",
 "limits": [
 0.0,
@@ -1227,7 +1227,7 @@ null
 "kind": "orbit",
 "context": "component",
 "description": "sum of fractional equivalent radii of children stars",
-"value": 0.8955223880597013,
+"value": 0.8955223880597052,
 "default_unit": "",
 "limits": [
 0.0,
@@ -2290,11 +2290,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": {
@@ -2526,11 +2526,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2544,11 +2544,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2754,7 +2754,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.11.dev+feature-interferometry",
+"value": "2.4.15",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_contact_binary.bundle
+++ b/phoebe/frontend/default_bundles/default_contact_binary.bundle
@@ -209,7 +209,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "logg at requiv",
-"value": 4.089736163094955,
+"value": 4.089736153779247,
 "default_unit": "",
 "limits": [
 null,
@@ -259,7 +259,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Rotation frequency (wrt the sky)",
-"value": 12.56637,
+"value": 12.566370614359172,
 "default_unit": "rad / d",
 "limits": [
 0.0,
@@ -426,8 +426,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"phoenix",
-"ck2004"
+"ck2004",
+"phoenix"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -460,7 +460,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Mass",
-"value": 1.0089067994531355,
+"value": 1.0089067893421308,
 "default_unit": "solMass",
 "limits": [
 1e-12,
@@ -557,7 +557,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "logg at requiv",
-"value": 4.089736163094955,
+"value": 4.089736153779248,
 "default_unit": "",
 "limits": [
 null,
@@ -607,7 +607,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Rotation frequency (wrt the sky)",
-"value": 12.56637,
+"value": 12.566370614359172,
 "default_unit": "rad / d",
 "limits": [
 0.0,
@@ -774,8 +774,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"phoenix",
-"ck2004"
+"ck2004",
+"phoenix"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -808,7 +808,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Mass",
-"value": 1.0089067994531355,
+"value": 1.0089067893421308,
 "default_unit": "solMass",
 "limits": [
 1e-12,
@@ -857,7 +857,7 @@ null
 "kind": "orbit",
 "context": "component",
 "description": "Orbital frequency (sidereal)",
-"value": 12.56637,
+"value": 12.566370614359172,
 "default_unit": "rad / d",
 "limits": [
 null,
@@ -988,7 +988,7 @@ null
 "kind": "orbit",
 "context": "component",
 "description": "Mean anomaly at t0@system",
-"value": 89.99999559997653,
+"value": 90.0,
 "default_unit": "deg",
 "limits": [
 null,
@@ -1324,7 +1324,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@primary@component}",
+"value": "6.28318530717958623e+00 / {period@primary@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -1340,7 +1340,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "log10((({mass@primary@component} / ({requiv@primary@component} ** 2.000000)) * 2942.206218) * 9.319541)",
+"value": "log10((({mass@primary@component} / ({requiv@primary@component} ** 2.000000)) * 2.94220621750441933e+03) * 9.31954089506172778e+00)",
 "default_unit": "",
 "constraint_func": "logg",
 "constraint_kwargs": {
@@ -1356,7 +1356,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "1.000000 - {irrad_frac_refl_bol@primary@component}",
+"value": "1.00000000000000000e+00 - {irrad_frac_refl_bol@primary@component}",
 "default_unit": "",
 "constraint_func": "irrad_frac",
 "constraint_kwargs": {
@@ -1372,7 +1372,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@secondary@component}",
+"value": "6.28318530717958623e+00 / {period@secondary@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -1388,7 +1388,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "log10((({mass@secondary@component} / ({requiv@secondary@component} ** 2.000000)) * 2942.206218) * 9.319541)",
+"value": "log10((({mass@secondary@component} / ({requiv@secondary@component} ** 2.000000)) * 2.94220621750441933e+03) * 9.31954089506172778e+00)",
 "default_unit": "",
 "constraint_func": "logg",
 "constraint_kwargs": {
@@ -1404,7 +1404,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "1.000000 - {irrad_frac_refl_bol@secondary@component}",
+"value": "1.00000000000000000e+00 - {irrad_frac_refl_bol@secondary@component}",
 "default_unit": "",
 "constraint_func": "irrad_frac",
 "constraint_kwargs": {
@@ -1468,7 +1468,7 @@ null
 "kind": "orbit",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "{period@binary@component} / ((((-1.000000 * {period@binary@component}) * {dperdt@binary@component}) / 6.283185307179586231995926937088) + 1.000000000000000000000000000000)",
+"value": "{period@binary@component} / ((((-1.00000000000000000e+00 * {period@binary@component}) * {dperdt@binary@component}) / 6.28318530717958623e+00) + 1.00000000000000000e+00)",
 "default_unit": "d",
 "constraint_func": "period_anom",
 "constraint_kwargs": {
@@ -1484,7 +1484,7 @@ null
 "kind": "orbit",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "(6.283185 * ({t0@system} - {t0_perpass@binary@component})) / {period@binary@component}",
+"value": "(6.28318530717958623e+00 * ({t0@system} - {t0_perpass@binary@component})) / {period@binary@component}",
 "default_unit": "deg",
 "constraint_func": "mean_anom",
 "constraint_kwargs": {
@@ -1542,7 +1542,7 @@ null
 "kind": "orbit",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@binary@component}",
+"value": "6.28318530717958623e+00 / {period@binary@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -1698,7 +1698,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "(39.478418 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ({q@binary@component} + 1.000000)) * 2942.206217504419328179210424423218)",
+"value": "(3.94784176043574320e+01 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ({q@binary@component} + 1.000000)) * 2.94220621750441933e+03)",
 "default_unit": "solMass",
 "constraint_func": "mass",
 "constraint_kwargs": {
@@ -1720,7 +1720,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "{sma@binary@component} / ((1.000000 / {q@binary@component}) + 1.000000)",
+"value": "{sma@binary@component} / ((1.00000000000000000e+00 / {q@binary@component}) + 1.00000000000000000e+00)",
 "default_unit": "solRad",
 "constraint_func": "comp_sma",
 "constraint_kwargs": {
@@ -1736,7 +1736,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "({sma@binary@component} * (sin({incl@binary@component}))) / ((1.000000 / {q@binary@component}) + 1.000000)",
+"value": "({sma@binary@component} * (sin({incl@binary@component}))) / ((1.00000000000000000e+00 / {q@binary@component}) + 1.00000000000000000e+00)",
 "default_unit": "solRad",
 "constraint_func": "comp_asini",
 "constraint_kwargs": {
@@ -1832,7 +1832,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "(39.478418 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ((1.000000 / {q@binary@component}) + 1.000000)) * 2942.206217504419328179210424423218)",
+"value": "(3.94784176043574320e+01 * ({sma@binary@component} ** 3.000000)) / ((({period@binary@component} ** 2.000000) * ((1.00000000000000000e+00 / {q@binary@component}) + 1.00000000000000000e+00)) * 2.94220621750441933e+03)",
 "default_unit": "solMass",
 "constraint_func": "mass",
 "constraint_kwargs": {
@@ -2290,11 +2290,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": {
@@ -2526,11 +2526,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2544,11 +2544,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -2754,7 +2754,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.6",
+"value": "2.4.11.dev+feature-interferometry",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_star.bundle
+++ b/phoebe/frontend/default_bundles/default_star.bundle
@@ -426,8 +426,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"ck2004",
-"phoenix"
+"phoenix",
+"ck2004"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -877,11 +877,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": {
@@ -1033,11 +1033,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"ck2004",
 "phoenix",
 "extern_atmx",
-"extern_planckint",
-"blackbody"
+"ck2004",
+"blackbody",
+"extern_planckint"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -1148,7 +1148,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.11.dev+feature-interferometry",
+"value": "2.4.15",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/frontend/default_bundles/default_star.bundle
+++ b/phoebe/frontend/default_bundles/default_star.bundle
@@ -144,7 +144,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Critical (maximum) value of the equivalent radius for the given morphology",
-"value": 3.4292622920441116,
+"value": 3.429265859647371,
 "default_unit": "solRad",
 "limits": [
 0.0,
@@ -209,7 +209,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "logg at requiv",
-"value": 4.438067632266453,
+"value": 4.438067627303133,
 "default_unit": "",
 "limits": [
 null,
@@ -259,7 +259,7 @@ null
 "kind": "star",
 "context": "component",
 "description": "Rotation frequency (wrt the sky)",
-"value": 6.283185,
+"value": 6.283185307179586,
 "default_unit": "rad / d",
 "limits": [
 0.0,
@@ -426,8 +426,8 @@ null
 "description": "Source for bolometric limb darkening coefficients (used only for irradiation; 'auto' to interpolate from the applicable table according to the 'atm' parameter, or the name of a specific atmosphere table)",
 "choices": [
 "auto",
-"phoenix",
-"ck2004"
+"ck2004",
+"phoenix"
 ],
 "value": "auto",
 "visible_if": "ld_mode_bol:lookup",
@@ -489,7 +489,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "6.283185 / {period@starA@component}",
+"value": "6.28318530717958623e+00 / {period@starA@component}",
 "default_unit": "rad / d",
 "constraint_func": "freq",
 "constraint_kwargs": {
@@ -505,7 +505,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "log10((({mass@starA@component} / ({requiv@starA@component} ** 2.000000)) * 2942.206218) * 9.319541)",
+"value": "log10((({mass@starA@component} / ({requiv@starA@component} ** 2.000000)) * 2.94220621750441933e+03) * 9.31954089506172778e+00)",
 "default_unit": "",
 "constraint_func": "logg",
 "constraint_kwargs": {
@@ -521,7 +521,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "1.000000 - {irrad_frac_refl_bol@starA@component}",
+"value": "1.00000000000000000e+00 - {irrad_frac_refl_bol@starA@component}",
 "default_unit": "",
 "constraint_func": "irrad_frac",
 "constraint_kwargs": {
@@ -537,7 +537,7 @@ null
 "kind": "star",
 "context": "constraint",
 "description": "expression that determines the constraint",
-"value": "0.814886 * (((2942.206218 * {mass@starA@component}) * (({period@starA@component} / 6.283185) ** 2.000000)) ** 0.333333)",
+"value": "8.14885676770049971e-01 * (((2.94220621750441933e+03 * {mass@starA@component}) * (({period@starA@component} / 6.283185) ** 2.00000000000000000e+00)) ** 3.33333333333333315e-01)",
 "default_unit": "solRad",
 "constraint_func": "requiv_single_max",
 "constraint_kwargs": {
@@ -877,11 +877,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": {
@@ -1033,11 +1033,11 @@ null
 "context": "compute",
 "description": "Atmosphere table",
 "choices": [
-"extern_atmx",
-"blackbody",
-"extern_planckint",
+"ck2004",
 "phoenix",
-"ck2004"
+"extern_atmx",
+"extern_planckint",
+"blackbody"
 ],
 "value": "ck2004",
 "copy_for": false,
@@ -1148,7 +1148,7 @@ null
 "qualifier": "phoebe_version",
 "context": "setting",
 "description": "Version of PHOEBE",
-"value": "2.4.6",
+"value": "2.4.11.dev+feature-interferometry",
 "copy_for": false,
 "readonly": true,
 "advanced": true,

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -7691,7 +7691,7 @@ class Parameter(object):
                 else:
                     # assume dimensionless
                     other = float(other)*u.dimensionless_unscaled
-                return ConstraintParameter(self._bundle, "%f %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "%0.30f %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, u.Unit) and mathfunc=='__mul__':
                 return self.quantity*other
             else:
@@ -11821,7 +11821,7 @@ class ConstraintParameter(Parameter):
             else:
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
-            return ConstraintParameter(self._bundle, "(%s) %s %f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "(%s) %s %0.30f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, str):
             return ConstraintParameter(self._bundle, "(%s) %s %s" % (self.expr, symbol, other), default_unit=(getattr(self.result, mathfunc)(eval(other)).unit))
         elif _is_unit(other) and mathfunc=='__mul__':
@@ -11847,7 +11847,7 @@ class ConstraintParameter(Parameter):
             else:
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
-            return ConstraintParameter(self._bundle, "%f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "%0.30f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, str):
             return ConstraintParameter(self._bundle, "%s %s (%s)" % (other, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(eval(other)).unit))
         elif _is_unit(other) and mathfunc=='__mul__':

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -7658,7 +7658,7 @@ class Parameter(object):
                 default_unit = getattr(self_quantity, mathfunc)(other_quantity).unit
                 return ConstraintParameter(self._bundle, "{%s} %s {%s}" % (self.uniquetwig, symbol, other.uniquetwig), default_unit=default_unit)
             elif isinstance(other, u.Quantity):
-                return ConstraintParameter(self._bundle, "{%s} %s %0.30f" % (self.uniquetwig, symbol, _value_for_constraint(other)), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "{%s} %s %0.17e" % (self.uniquetwig, symbol, _value_for_constraint(other)), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, float) or isinstance(other, int):
                 if symbol in ['+', '-'] and hasattr(self, 'default_unit'):
                     # assume same units as self (NOTE: NOT NECESSARILY SI) if addition or subtraction
@@ -7683,7 +7683,7 @@ class Parameter(object):
             elif isinstance(other, Parameter):
                 return ConstraintParameter(self._bundle, "{%s} %s {%s}" % (other.uniquetwig, symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other.quantity).unit))
             elif isinstance(other, u.Quantity):
-                return ConstraintParameter(self._bundle, "%0.30f %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "%0.17e %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, float) or isinstance(other, int):
                 if symbol in ['+', '-'] and hasattr(self, 'default_unit'):
                     # assume same units as self if addition or subtraction
@@ -7691,7 +7691,7 @@ class Parameter(object):
                 else:
                     # assume dimensionless
                     other = float(other)*u.dimensionless_unscaled
-                return ConstraintParameter(self._bundle, "%0.30f %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
+                return ConstraintParameter(self._bundle, "%0.17e %s {%s}" % (_value_for_constraint(other), symbol, self.uniquetwig), default_unit=(getattr(self.quantity, mathfunc)(other).unit))
             elif isinstance(other, u.Unit) and mathfunc=='__mul__':
                 return self.quantity*other
             else:
@@ -11813,7 +11813,7 @@ class ConstraintParameter(Parameter):
             return ConstraintParameter(self._bundle, "(%s) %s {%s}" % (self.expr, symbol, other.uniquetwig), default_unit=(getattr(self.result, mathfunc)(other.quantity).unit))
         elif isinstance(other, u.Quantity):
             #print "***", other, type(other), isinstance(other, ConstraintParameter)
-            return ConstraintParameter(self._bundle, "(%s) %s %0.30f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "(%s) %s %0.17e" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, float) or isinstance(other, int):
             if symbol in ['+', '-']:
                 # assume same units as self (NOTE: NOT NECESSARILY SI) if addition or subtraction
@@ -11821,7 +11821,7 @@ class ConstraintParameter(Parameter):
             else:
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
-            return ConstraintParameter(self._bundle, "(%s) %s %0.30f" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "(%s) %s %0.17e" % (self.expr, symbol, _value_for_constraint(other, self)), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, str):
             return ConstraintParameter(self._bundle, "(%s) %s %s" % (self.expr, symbol, other), default_unit=(getattr(self.result, mathfunc)(eval(other)).unit))
         elif _is_unit(other) and mathfunc=='__mul__':
@@ -11839,7 +11839,7 @@ class ConstraintParameter(Parameter):
             return ConstraintParameter(self._bundle, "{%s} %s (%s)" % (other.uniquetwig, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other.quantity).unit))
         elif isinstance(other, u.Quantity):
             #~ print "*** rmath", other, type(other)
-            return ConstraintParameter(self._bundle, "%0.30f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "%0.17e %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, float) or isinstance(other, int):
             if symbol in ['+', '-']:
                 # assume same units as self if addition or subtraction
@@ -11847,7 +11847,7 @@ class ConstraintParameter(Parameter):
             else:
                 # assume dimensionless
                 other = float(other)*u.dimensionless_unscaled
-            return ConstraintParameter(self._bundle, "%0.30f %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
+            return ConstraintParameter(self._bundle, "%0.17e %s (%s)" % (_value_for_constraint(other, self), symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(other).unit))
         elif isinstance(other, str):
             return ConstraintParameter(self._bundle, "%s %s (%s)" % (other, symbol, self.expr), default_unit=(getattr(self.result, mathfunc)(eval(other)).unit))
         elif _is_unit(other) and mathfunc=='__mul__':


### PR DESCRIPTION
This is formatting of strings in constraints, which is necessary for double precision. Beware that "%.30f" is not enough for tiny numbers! It is safe to use "%.17e" though. 