### PR TITLE
Fixes invalid escape sequences

### DIFF
--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -583,7 +583,7 @@ class Passband:
         return hclkt * expterm/(expterm-1)
 
     def _bb_intensity(self, Teff, photon_weighted=False):
-        """
+        r"""
         Computes mean passband intensity using blackbody atmosphere:
 
         I_pb^E = \int_\lambda I(\lambda) P(\lambda) d\lambda / \int_\lambda P(\lambda) d\lambda
@@ -609,7 +609,7 @@ class Passband:
             return integrate.quad(pb, self.wl[0], self.wl[-1])[0]/self.ptf_area
 
     def _bindex_blackbody(self, Teff, photon_weighted=False):
-        """
+        r"""
         Computes the mean boosting index using blackbody atmosphere:
 
         B_pb^E = \int_\lambda I(\lambda) P(\lambda) B(\lambda) d\lambda / \int_\lambda I(\lambda) P(\lambda) d\lambda
@@ -1689,7 +1689,7 @@ class Passband:
             f.close()
 
     def compute_ck2004_ldints(self):
-        """
+        r"""
         Computes integrated limb darkening profiles for ck2004 atmospheres.
         These are used for intensity-to-flux transformations. The evaluated
         integral is:
@@ -1736,7 +1736,7 @@ class Passband:
             self.content.append('ck2004:ldint')
 
     def compute_phoenix_ldints(self):
-        """
+        r"""
         Computes integrated limb darkening profiles for PHOENIX atmospheres.
         These are used for intensity-to-flux transformations. The evaluated
         integral is:
@@ -2091,7 +2091,7 @@ class Passband:
         return 10**Imu
 
     def Inorm(self, Teff=5772., logg=4.43, abun=0.0, atm='ck2004', ldatm='ck2004', ldint=None, ld_func='interp', ld_coeffs=None, photon_weighted=False):
-        """
+        r"""
 
         Arguments
         ----------
@@ -2171,7 +2171,7 @@ class Passband:
         return retval
 
     def Imu(self, Teff=5772., logg=4.43, abun=0.0, mu=1.0, atm='ck2004', ldatm='ck2004', ldint=None, ld_func='interp', ld_coeffs=None, photon_weighted=False):
-        """
+        r"""
         Arguments
         ----------
         * `Teff`
@@ -3242,7 +3242,7 @@ def get_passband(passband, content=None, reload=False, update_if_necessary=False
     return _pbtable[passband]['pb']
 
 def Inorm_bol_bb(Teff=5772., logg=4.43, abun=0.0, atm='blackbody', photon_weighted=False):
-    """
+    r"""
     Computes normal bolometric intensity using the Stefan-Boltzmann law,
     Inorm_bol_bb = 1/\pi \sigma T^4. If photon-weighted intensity is
     requested, Inorm_bol_bb is multiplied by a conversion factor that

--- a/phoebe/dependencies/crimpl/common.py
+++ b/phoebe/dependencies/crimpl/common.py
@@ -394,7 +394,7 @@ class Server(object):
             logenv_cmd = self.ssh_cmd.format("echo \'{}\' > {}".format(conda_env, _os.path.join(directory, "crimpl-conda-environment")))
 
         # TODO: use job subdirectory for server_path
-        scp_cmd = self.scp_cmd_to.format(local_path=" ".join([script_fname]+[_os.path.normpath(f).replace(' ', '\ ') for f in files]), server_path=directory+"/")
+        scp_cmd = self.scp_cmd_to.format(local_path=" ".join([script_fname]+[_os.path.normpath(f).replace(' ', r'\ ') for f in files]), server_path=directory+"/")
 
         if use_scheduler:
             if use_scheduler == 'slurm':

--- a/phoebe/dependencies/distl/distl.py
+++ b/phoebe/dependencies/distl/distl.py
@@ -239,7 +239,7 @@ class Latex(object):
 
     @property
     def as_latex(self):
-        return r"\begin{align} "+self._stex+" \end{align}"
+        return r"\begin{align} " + self._stex + r" \end{align}"
 
     @property
     def as_latex_list(self):
@@ -319,7 +319,7 @@ def _format_uncertainties_asymmetric(labels, labels_latex, units, qs_per_dim):
         unitstr = " "+unit.to_string() if unit is not None else ""
         unittex_spacer = "" if unit is None or unit in [_units.deg, _units.dimensionless_unscaled] else "~"
         unittex = unittex_spacer + unit._repr_latex_().replace('$', '') if unit is not None else ''
-        stex += "\mathrm{{ {} }} &= {}^{{ +{} }}_{{ -{} }} {} \\\\ ".format(label_latex.replace("$", ""), _np.round(qs[1], ndigits), _np.round(qs[2]-qs[1], ndigits), _np.round(qs[1]-qs[0], ndigits), unittex)
+        stex += r"\mathrm{{ {} }} &= {}^{{ +{} }}_{{ -{} }} {} \\\\ ".format(label_latex.replace("$", ""), _np.round(qs[1], ndigits), _np.round(qs[2]-qs[1], ndigits), _np.round(qs[1]-qs[0], ndigits), unittex)
         s += "{} = {} +{} -{} {}\n".format(label, _np.round(qs[1], ndigits), _np.round(qs[2]-qs[1], ndigits), _np.round(qs[1]-qs[0], ndigits), unitstr)
 
     return Latex(s, stex)
@@ -350,7 +350,7 @@ def _format_uncertainties_symmetric(labels, labels_latex, units, values_per_dim,
         unitstr = " "+unit.to_string() if unit is not None else ""
         unittex_spacer = "" if unit is None or unit in [_units.deg, _units.dimensionless_unscaled] else "~"
         unittex = unittex_spacer + unit._repr_latex_().replace('$', '') if unit is not None else ''
-        stex += "\mathrm{{ {} }} &= {}\pm{{ {} }} {} \\\\ ".format(label_latex.replace("$", ""), _np.round(value, ndigits), _np.round(sigma, ndigits), unittex)
+        stex += "\\mathrm{{ {} }} &= {} \\pm {{ {} }} {} \\\\ ".format(label_latex.replace("$", ""), _np.round(value, ndigits), _np.round(sigma, ndigits), unittex)
         s += "{} = {} +/- {} {}\n".format(label, _np.round(value, ndigits), _np.round(sigma, ndigits), unitstr)
 
     return Latex(s, stex)
@@ -4427,9 +4427,9 @@ class DistributionCollection(BaseDistlObject):
         bounds = _np.percentile(models, 100 * _norm.cdf([-2, -1, 1, 2]), axis=0)
 
         ret1 = _plt.fill_between(x, bounds[0, :], bounds[-1, :],
-                         label="95\% uncertainty", facecolor="#03A9F4", alpha=0.4)
+                         label=r"95\% uncertainty", facecolor="#03A9F4", alpha=0.4)
         ret2 = _plt.fill_between(x, bounds[1, :], bounds[-2, :],
-                         label="68\% uncertainty", facecolor="#0288D1", alpha=0.4)
+                         label=r"68\% uncertainty", facecolor="#0288D1", alpha=0.4)
 
         if show:
             _plt.show()
@@ -4481,7 +4481,7 @@ class Composite(BaseUnivariateDistribution):
     Limitations and treatment "under-the-hood":
 
     * &: the pdfs of the two underlying distributions are sampled over their
-        99.99\% intervals and multiplied to create a new pdf.  A spline is then
+        99.99% intervals and multiplied to create a new pdf.  A spline is then
         fit to the pdf and integrated to create the cdf (which is inverted to
         create the ppf function).  Each of these are then linearly interpolated
         to create the underlying scipy.stats object.  This object is then used
@@ -4490,7 +4490,7 @@ class Composite(BaseUnivariateDistribution):
         retaining covariances at all.
 
     * |: the pdfs and cdfs of the two underlying distributions are sampled over their
-        99.9\% intervals and added to create the new pdfs and cdfs, respectively
+        99.9% intervals and added to create the new pdfs and cdfs, respectively
         (and the cdf inverted to create the ppf function).  Each of these are then
         linearly interpolated to create the underlying scipy.stats object.  This
         object is then used for any call to the underlying call EXCEPT for sampling.

--- a/phoebe/dependencies/ligeor/models/twogaussian.py
+++ b/phoebe/dependencies/ligeor/models/twogaussian.py
@@ -156,7 +156,7 @@ class TwoGaussianModel(Model):
 
     @staticmethod
     def ellipsoidal(phi, Aell, phi0):
-        '''
+        r'''
         Ellipsoidal model, defined as $y = (1/2) A_{ell} \cos (4 \pi (\phi - \phi_0))$
         
         Parameters
@@ -178,7 +178,7 @@ class TwoGaussianModel(Model):
 
     @staticmethod
     def gaussian(phi, mu, d, sigma):
-        '''
+        r'''
         Gaussian model, defined as $y = d \exp(-(\phi-\mu)^2/(2\sigma^2))$
 
         Parameters
@@ -431,7 +431,7 @@ class TwoGaussianModel(Model):
 
     @staticmethod
     def lnlike(y, yerr, ymodel):
-        '''
+        r'''
         Computes the loglikelihood of a model.
 
         $\log\mathrm{like} = \sum_i \log(\sqrt{2\pi} \sigma_i) + (y_i - model_i)^2/(2\sigma_i^2)
@@ -442,7 +442,7 @@ class TwoGaussianModel(Model):
             return -np.sum((y-ymodel)**2)
 
     def bic(self, ymodel, nparams):
-        '''
+        r'''
         Computes the Bayesian Information Criterion (BIC) value of a model.
 
         BIC = 2 lnlike - n_params \log(n_data)


### PR DESCRIPTION
Strings with invalid escape sequences raised a deprecation syntax warning in python 3.11 but a syntax error in 3.12+. All instances (at least the ones that present themselves at import time) have been fixed.