### PR TITLE
only run CI checks on PRs to avoid duplication

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -3,11 +3,6 @@ name: Latest per-python environments
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - 'master'
-      - 'feature-*'
-      - 'bugfix-*'
 
 jobs:
   build:


### PR DESCRIPTION
otherwise PRs from any of these branches end up resulting in the entire workflow running twice.  Only in very rare exceptions do we ever push directly to these branches without going through a PR. 