### PR TITLE
python 3.13 support

### DIFF
--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
-        os: [ubuntu-22.04, macos-13, macos-14]  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        os: [ubuntu-lateset, macos-13, macos-14, macos-latest]  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         toolchain:
             - {compiler: gcc, version: 13}  # https://github.com/fortran-lang/setup-fortran
 

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.13"]
         os: [ubuntu-22.04, macos-13, macos-14]  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         toolchain:
             - {compiler: gcc, version: 13}  # https://github.com/fortran-lang/setup-fortran

--- a/.github/workflows/on_pr.yml
+++ b/.github/workflows/on_pr.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-lateset, macos-13, macos-14, macos-latest]  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+        os: [ubuntu-latest, macos-13, macos-14, macos-latest]  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
         toolchain:
             - {compiler: gcc, version: 13}  # https://github.com/fortran-lang/setup-fortran
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ CHANGELOG
 
 * Fix handling of floating-point precision near the aligned case that used to result in error from libphoebe. [#965]
 * Updates to phoebe-server to be compatible with modern browser requirements. [#959]
+* Fix support for python 3.13, remove official support for python 3.8. [#968]
 
 
 ### 2.4.15

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ CHANGELOG
 
 * Fix handling of floating-point precision near the aligned case that used to result in error from libphoebe. [#965]
 * Updates to phoebe-server to be compatible with modern browser requirements. [#959]
-* Fix support for python 3.13, remove official support for python 3.8. [#968]
+* Fix support for python 3.13, remove official support for python 3.7. [#968]
 
 
 ### 2.4.15

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -12024,7 +12024,8 @@ class ConstraintParameter(Parameter):
                     # to do from builtin import * (and even if I did, python
                     # yells at me for doing that), so instead we'll add them
                     # to the locals dictionary.
-                    locals()[func] = getattr(builtin, func)
+                    # See https://peps.python.org/pep-0667/
+                    sys._getframe().f_locals[func] = getattr(builtin, func)
 
                 # if eq.split('(')[0] in ['times_to_phases', 'phases_to_times']:
                     # these require passing the bundle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "phoebe"
 version = "2.4.16"
 description = "PHOEBE: modeling and analysis of eclipsing binary stars"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { text = "GPL-3.0-or-later" }
 authors = [
     { name = "Andrej Prša", email = "aprsa@villanova.edu" },


### PR DESCRIPTION
This PR is to test python 3.13 support and eventually make phoebe compatible.

Before merge:
- [x] decide which version of python we want kept in the test matrix (currently only testing 3.13 to see what other errors arise).

Closes #967 