### PR TITLE
Vectorization of passband computations

### DIFF
--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -751,11 +751,15 @@ class Passband:
 
             for ti, teff in enumerate(teffs):
                 bb_sed = self._planck(self.wl, teff)
+                ptf = self.ptf(self.wl)
+                eweight = np.trapz(ptf * bb_sed, axis=0)
+                pweight = np.trapz(self.wl * ptf * bb_sed, axis=0)
+
                 for ei, ebv in enumerate(ebvs):
                     for ri, rv in enumerate(rvs):
                         Alam = 10**(-0.4 * ebv * (rv * ax + bx))
-                        egrid[ti, ei, ri, 0] = np.trapz(self.ptf(self.wl) * bb_sed * Alam, axis=0) / np.trapz(self.ptf(self.wl) * bb_sed, axis=0)
-                        pgrid[ti, ei, ri, 0] = np.trapz(self.wl * self.ptf(self.wl) * bb_sed * Alam, axis=0) / np.trapz(self.wl * self.ptf(self.wl) * bb_sed, axis=0)
+                        egrid[ti, ei, ri, 0] = np.trapz(self.ptf(self.wl) * bb_sed * Alam, axis=0) / eweight
+                        pgrid[ti, ei, ri, 0] = np.trapz(self.wl * self.ptf(self.wl) * bb_sed * Alam, axis=0) / pweight
 
             self.ndp['blackbody'] = ndpolator.Ndpolator(basic_axes=(axes[0],))
             self.ndp['blackbody'].register('ext@photon', associated_axes=(axes[1], axes[2]), grid=pgrid)

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -905,14 +905,6 @@ class Passband:
                     ext_energy_grid[t] = egrid.reshape(len(ebvs), len(rvs), 1)
                     ext_photon_grid[t] = pgrid.reshape(len(ebvs), len(rvs), 1)
 
-                    # WORKS:
-                    # for ei, ebv in enumerate(ebvs):
-                    #     for ri, rv in enumerate(rvs):
-                    #         Alam = 10**(-0.4 * ebv * (rv * ax + bx))
-                    #         t = (teffs[i] == ext_axes[0], loggs[i] == ext_axes[1], abuns[i] == ext_axes[2], ebvs[ei] == ext_axes[3], rvs[ri] == ext_axes[4],0)
-                    #         ext_energy_grid[t] = np.trapz(ptf * seds * Alam, wls)[-1] / np.trapz(ptf * seds, wls)[-1]
-                    #         ext_photon_grid[t] = np.trapz(wls * ptf * seds * Alam, wls)[-1] / np.trapz(wls * ptf * seds, wls)[-1]
-
         basic_axes = (np.unique(teffs), np.unique(loggs), np.unique(abuns))
         self.ndp[atm] = ndpolator.Ndpolator(basic_axes=basic_axes)
 


### PR DESCRIPTION
Extinction has been computed serially, which caused the computations to take a long time (~1 day per passband). The new vectorized approach for both blackbody atmospheres and model atmospheres speeds this up to ~5 minutes per passband. The generated tables were checked for correctness and they're indistinguishable from the previous runs to machine precision.