### PR TITLE
Fixes passband history adding/parsing

### DIFF
--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -353,7 +353,7 @@ class Passband:
         if len(comment) > max_length:
             raise ValueError(f'comment length should not exceed {max_length} characters.')
 
-        self.comments.append(comment)                
+        self.comments.append(comment)
 
     def on_updated_ptf(self, ptf, wlunits=u.AA, oversampling=1, ptf_order=3):
         """


### PR DESCRIPTION
In previous versions, history was overloading the HISTORY keyword in fits files and implementing a custom -END- separator, thus defeating the purpose of the fits standard. This has now been replaced with multiple HISTORY entries in the fits files.

Also, the timestamps thus far were in the ctime() format, which is locale-dependent. The new format follows the ISO standard and is locale-independent.

All parsers are implemented to use either format.

This version is currently serving passbands on staging.phoebe-project.org and everything is working as expected. Thus, I propose to pull this into the blending feature branch and use it to serve the passbands from the official tables.phoebe-project.org API.