### PR TITLE
Fix boosting for new atmosphere framework

### DIFF
--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1907,7 +1907,8 @@ class Star(Body):
 
             # boosting is aspect dependent so we don't need to correct the
             # normal intensities
-            abs_intensities *= boost_factors
+            abs_intensities *= np.array([np.ones(len(abs_intensities))*boost_factors]).T
+
 
             # interstellar extinction (reddening):
             if extinct == 0.0 or ignore_effects:

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1907,7 +1907,7 @@ class Star(Body):
 
             # boosting is aspect dependent so we don't need to correct the
             # normal intensities
-            abs_intensities *= np.array([np.ones(len(abs_intensities))*boost_factors]).T
+            abs_intensities *= np.atleast_2d(boost_factors).T
 
 
             # interstellar extinction (reddening):


### PR DESCRIPTION
Looks like the new atmosphere framework broke boosting due to a numpy shape mismatch. I think this (inelegantly) fixes that.