### PR TITLE
Interval weighted LD coeffs

### DIFF
--- a/phoebe/atmospheres/models.py
+++ b/phoebe/atmospheres/models.py
@@ -74,6 +74,9 @@ class ModelAtmosphere:
     # default axes:
     basic_axis_names = ['teffs', 'loggs', 'abuns']
 
+    # default LD coeff behaviour
+    ldweighting = 'uniform'
+
     def __init__(self, basic_axes=None, from_path=False):
         if from_path:
             return
@@ -346,6 +349,7 @@ class TremblayModelAtmosphere(ModelAtmosphere):
     prefix = 'tr'
 
     basic_axis_names = ['teffs', 'loggs']
+    ldweighting = 'interval'
 
     mus = np.array([
         0., 0.0034357 , 0.01801404, 0.04388279, 0.08044151, 0.12683405, 
@@ -376,6 +380,7 @@ class TMAPDOModelAtmosphere(ModelAtmosphere):
     prefix = 'to'
 
     basic_axis_names = ['teffs', 'loggs']
+    ldweighting = 'interval'
 
     mus = np.array([
         0., 0.00136799, 0.00719419, 0.01761889, 0.03254691, 0.05183939, 0.07531619,
@@ -408,6 +413,7 @@ class TMAPDAModelAtmosphere(ModelAtmosphere):
     prefix = 'ta'
 
     basic_axis_names = ['teffs', 'loggs']
+    ldweighting = 'interval'
 
     mus = np.array([
         0., 0.00136799, 0.00719419, 0.01761889, 0.03254691, 0.05183939, 0.07531619,
@@ -435,6 +441,7 @@ class TMAPsdOModelAtmosphere(ModelAtmosphere):
     name = 'tmap_sdO'
     prefix = 'ts'
     basic_axis_names = ['teffs', 'loggs', 'abuns']
+    ldweighting = 'interval'
 
     mus = np.array([0., 0.00136799, 0.00719419, 0.01761889, 0.03254691, 
                     0.05183939, 0.07531619, 0.10275816, 0.13390887, 0.16847785,
@@ -461,6 +468,7 @@ class TMAPDAOModelAtmosphere(ModelAtmosphere):
     name = 'tmap_DAO'
     prefix = 'tm'
     basic_axis_names = ['teffs', 'loggs', 'abuns']
+    ldweighting = 'interval'
 
     mus = np.array([0., 0.00136799, 0.00719419, 0.01761889, 0.03254691, 
                     0.05183939, 0.07531619, 0.10275816, 0.13390887, 0.16847785,

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -932,9 +932,10 @@ class Passband:
             def ld_resids(x, *args, **kwargs):
                 xdata = kwargs.get('xdata')
                 ydata = kwargs.get('ydata')
+                sigmas = kwargs.get('sigmas') 
                 ld_func = kwargs.get('ld_func', 'linear')
 
-                return self.ld_func(mu=xdata, ld_coeffs=x, ld_func=ld_func) - ydata
+                return (self.ld_func(mu=xdata, ld_coeffs=x, ld_func=ld_func) - ydata)/sigmas
 
             # loop over all defined coordinates to compute limb darkening coefficients and integrals:
             for grid, ld_grid, ldint_grid in zip([atm_energy_grid, atm_photon_grid], [ld_energy_grid, ld_photon_grid], [ldint_energy_grid, ldint_photon_grid]):
@@ -942,11 +943,16 @@ class Passband:
                     xdata = atm.mus
                     ydata = 10**grid[tuple(ind)].flatten()
                     ydata /= ydata[-1]
-                    # TODO: consider support for non-uniform weighing
+                
+                    if atm.ldweighting == 'uniform':
+                        sigmas = np.ones(len(xdata))
+                    elif atm.ldweighting == 'interval':
+                        delta = np.concatenate( (np.array((xdata[1]-xdata[0],)), xdata[1:]-xdata[:-1]))
+                        sigmas = 1./np.sqrt(delta)
 
                     ld_row = []
                     for ld_func, ld_dim in zip(['linear', 'logarithmic', 'square_root', 'quadratic', 'power'], [1, 2, 2, 2, 4]):
-                        result = least_squares(fun=ld_resids, x0=np.full(ld_dim, 0.5), method='lm', kwargs={'xdata': xdata, 'ydata': ydata, 'ld_func': ld_func})
+                        result = least_squares(fun=ld_resids, x0=np.full(ld_dim, 0.5), method='lm', kwargs={'xdata': xdata, 'ydata': ydata, 'sigmas': sigmas, 'ld_func': ld_func})
                         ld_row.append(result.x)
 
                     ld_grid[tuple(ind)] = np.hstack(ld_row)


### PR DESCRIPTION
Brings back interval weighting for LD coefficient calculation.  Not particularly important for CK and Phoenix but critical for white dwarf atms where the variation of Imu is very sharp and mu isn't regularly spaced.