### PR TITLE
Adds dockerizing capability.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3-alpine
+
+ARG PHOEBE_BRANCH=master
+
+RUN apk add --no-cache \
+      git \
+      build-base \
+      musl-dev
+
+RUN git clone --branch ${PHOEBE_BRANCH} --single-branch --depth 1 \
+      https://github.com/phoebe-project/phoebe2.git /phoebe
+
+WORKDIR /phoebe
+
+RUN pip install --upgrade pip
+
+RUN pip install --no-cache-dir .
+
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+ENTRYPOINT ["python", "-c", "import sys, phoebe; print(f'Python {sys.version}\\nPHOEBE {phoebe.__version__}')"]


### PR DESCRIPTION
This Dockerfile builds a base (parent) image that can be used for streamlined inheritance for any app that uses phoebe under the hood. It supports deploying containers for different branches. To build an image, do:

```bash
docker build --build-arg PHOEBE_BRANCH=master -f Dockerfile -t phoebe2:main .
```

Replace the branch name and the tag appropriately for other branches. To test an image, do:

```bash
docker run --rm phoebe2:main
```

This will print the python version and the phoebe version and exit.

To reiterate, this docker image is not meant to be used as a standalone service but as a base (parent) image for other containers, for example the tables server or the UI or anything else that requires phoebe.