### PR TITLE
fix continue_from support for scipy optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ CHANGELOG
 * Fix handling of spots in single star rotstar case where spots were not co-rotating properly [#1017]
 * Fix misaligned spots bug that caused size of spot to change across the rotation period [#1017]
 * Fix animation bug which prevented passing times as a numpy array [#1018]
+* Fix continue_from support for scipy optimizers [#1041]
 * Fix support for astropy 7.x units [#1043]
 
 ### 2.4.17

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -4696,7 +4696,7 @@ class Bundle(ParameterSet):
 
             if 'fit_parameters' in solver_ps.qualifiers:
                 fit_parameters = solver_ps.get_value(qualifier='fit_parameters', fit_parameters=kwargs.get('fit_parameters', None), expand=True, **_skip_filter_checks)
-                if not len(fit_parameters):
+                if not len(fit_parameters) and solver_ps.get_value(qualifier='continue_from', continue_from=kwargs.get('continue_from', None), **_skip_filter_checks).lower() == 'None':
                     report.add_item(self,
                                     "no valid parameters in fit_parameters",
                                     [solver_ps.get_parameter(qualifier='fit_parameters', **_skip_filter_checks)

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -4696,7 +4696,7 @@ class Bundle(ParameterSet):
 
             if 'fit_parameters' in solver_ps.qualifiers:
                 fit_parameters = solver_ps.get_value(qualifier='fit_parameters', fit_parameters=kwargs.get('fit_parameters', None), expand=True, **_skip_filter_checks)
-                if not len(fit_parameters) and solver_ps.get_value(qualifier='continue_from', continue_from=kwargs.get('continue_from', None), **_skip_filter_checks).lower() == 'None':
+                if not len(fit_parameters) and solver_ps.get_value(qualifier='continue_from', continue_from=kwargs.get('continue_from', None), **_skip_filter_checks).lower() == 'none':
                     report.add_item(self,
                                     "no valid parameters in fit_parameters",
                                     [solver_ps.get_parameter(qualifier='fit_parameters', **_skip_filter_checks)

--- a/phoebe/solverbackends/solverbackends.py
+++ b/phoebe/solverbackends/solverbackends.py
@@ -2020,7 +2020,8 @@ class _ScipyOptimizeBaseBackend(BaseSolverBackend):
 
     def run_checks(self, b, solver, compute, **kwargs):
         solver_ps = b.get_solver(solver=solver, **_skip_filter_checks)
-        if not len(solver_ps.get_value(qualifier='fit_parameters', fit_parameters=kwargs.get('fit_parameters', None), expand=True)):
+        continue_from = solver_ps.get_value(qualifier='continue_from', continue_from=kwargs.get('continue_from', None), **_skip_filter_checks)
+        if continue_from == 'None' and not len(solver_ps.get_value(qualifier='fit_parameters', fit_parameters=kwargs.get('fit_parameters', None), expand=True, **_skip_filter_checks)):
             raise ValueError("cannot run scipy.optimize.minimize(method='nelder-mead') without any parameters in fit_parameters")
 
 

--- a/tests/tests/test_optimizers/test_nm.py
+++ b/tests/tests/test_optimizers/test_nm.py
@@ -1,0 +1,69 @@
+import phoebe
+import numpy as np
+
+
+def test_nm_continue():
+    # modified from https://phoebe-project.org/docs/2.4/tutorials/nelder_mead
+    b = phoebe.default_binary()
+    b.set_value(qualifier='ecc', value=0.2)
+    b.set_value(qualifier='per0', value=25)
+    b.set_value(qualifier='teff', component='primary', value=7000)
+    b.set_value(qualifier='teff', component='secondary', value=6000)
+    b.set_value(qualifier='sma', component='binary', value=7)
+    b.set_value(qualifier='incl', component='binary', value=80)
+    b.set_value(qualifier='q', value=0.3)
+    b.set_value(qualifier='t0_supconj', value=0.1)
+    b.set_value(qualifier='requiv', component='primary', value=2.0)
+    b.set_value(qualifier='vgamma', value=80)
+
+    lctimes = phoebe.linspace(0, 10, 15)
+    rvtimes = phoebe.linspace(0, 10, 15)
+    b.add_dataset('lc', compute_times=lctimes)
+    b.add_dataset('rv', compute_times=rvtimes)
+
+    b.run_compute(irrad_method='none')
+
+    fluxes = b.get_value('fluxes@model') + np.random.normal(size=lctimes.shape) * 0.01
+    fsigmas = np.ones_like(lctimes) * 0.02
+
+    rvsA = b.get_value('rvs@primary@model') + np.random.normal(size=rvtimes.shape) * 10
+    rvsB = b.get_value('rvs@secondary@model') + np.random.normal(size=rvtimes.shape) * 10
+    rvsigmas = np.ones_like(rvtimes) * 20
+
+
+    b = phoebe.default_binary()
+
+    b.add_dataset('lc',
+                  compute_phases=phoebe.linspace(0,1,5),
+                  times=lctimes,
+                  fluxes=fluxes,
+                  sigmas=fsigmas,
+                  dataset='lc01')
+
+    b.add_dataset('rv',
+                  compute_phases=phoebe.linspace(0,1,5),
+                  times=rvtimes,
+                  rvs={'primary': rvsA, 'secondary': rvsB},
+                  sigmas=rvsigmas,
+                  dataset='rv01')
+
+    b.set_value('irrad_method', 'none')
+
+    b.set_value(qualifier='sma', component='binary', value=7+0.5)
+    b.set_value(qualifier='incl', component='binary', value=80+10)
+    b.set_value(qualifier='q', value=0.3+0.1)
+    b.set_value(qualifier='t0_supconj', value=0.1)
+    b.set_value(qualifier='requiv', component='primary', value=2.0-0.3)
+
+    b.add_solver('optimizer.nelder_mead', solver='nm_solver',
+                 fit_parameters=['teff', 'requiv'], maxiter=3)
+
+    b.run_solver(solver='nm_solver', solution='nm_solution')
+
+    b.add_solver('optimizer.nelder_mead', solver='nm_solver_contd',
+                 continue_from='nm_solution', maxiter=3)
+    b.run_solver(solver='nm_solver_contd', solution='nm_solution_contd')
+
+
+if __name__ == '__main__':
+    test_nm_continue()


### PR DESCRIPTION
This PR fixes `continue_from` support for scipy optimizers, including Nelder-Mead, and adds test coverage for this case.  This closes https://github.com/phoebe-project/phoebe2-docs/issues/45 