### PR TITLE
fix support for astropy 7 unit changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ CHANGELOG
 * Fix handling of spots in single star rotstar case where spots were not co-rotating properly [#1017]
 * Fix misaligned spots bug that caused size of spot to change across the rotation period [#1017]
 * Fix animation bug which prevented passing times as a numpy array [#1018]
-
+* Fix support for astropy 7.x units [#1043]
 
 ### 2.4.17
 

--- a/phoebe/dependencies/distl/distl.py
+++ b/phoebe/dependencies/distl/distl.py
@@ -76,7 +76,10 @@ _physical_types_to_solar = {'length': 'solRad',
                             'time': 'd',
                             'speed': 'solRad/d',
                             'angle': 'rad',
+                            'angular frequency': 'rad/d',
+                            'angular velocity': 'rad/d',
                             'angular speed': 'rad/d',
+                            'angular frequency/angular speed/angular velocity': 'rad/d',
                             'dimensionless': ''}
 
 _physical_types_to_si = {'length': 'm',
@@ -2109,7 +2112,7 @@ class BaseUnivariateDistribution(BaseDistribution):
         physical_type = str(self.unit.physical_type)
 
         if physical_type not in _physical_types_to_solar.keys():
-            raise NotImplementedError("cannot convert object with physical_type={} to solar units".format(physical_type))
+            raise NotImplementedError(f"cannot convert '{self.unit}' with physical_type='{physical_type}' to solar units")
 
         return self.to(_units.Unit(_physical_types_to_solar.get(physical_type)), strip_units=strip_units)
 
@@ -8431,7 +8434,7 @@ class BaseAroundGenerator(BaseDistlObject):
         physical_type = self.unit.physical_type
 
         if physical_type not in _physical_types_to_solar.keys():
-            raise NotImplementedError("cannot convert object with physical_type={} to solar units".format(physical_type))
+            raise NotImplementedError(f"cannot convert '{self.unit}' with physical_type='{physical_type}' to solar units")
 
         return self.to(_units.Unit(_physical_types_to_solar.get(physical_type)), strip_units=strip_units)
 

--- a/phoebe/dependencies/unitsiau2015/__init__.py
+++ b/phoebe/dependencies/unitsiau2015/__init__.py
@@ -57,6 +57,7 @@ _physical_types_to_solar = {'length': 'solRad',
                             'angular speed': 'rad/d',
                             'angular velocity': 'rad/d',
                             'angular frequency': 'rad/d',
+                            'angular frequency/angular speed/angular velocity': 'rad/d',
                             'dimensionless': ''}
 
 _physical_types_to_si = {'length': 'm',
@@ -114,7 +115,7 @@ def to_solar(object):
     physical_type = _get_physical_type(object)
 
     if physical_type not in _physical_types_to_solar.keys():
-        raise NotImplementedError("cannot convert object with physical_type={} to solar units".format(physical_type))
+        raise NotImplementedError(f"cannot convert '{object}' with physical_type='{physical_type}' to solar units")
 
     return object.to(_physical_types_to_solar.get(physical_type))
 


### PR DESCRIPTION
This PR fixes the astropy unit issues preventing creating a default binary with astropy 7.x seen in https://github.com/phoebe-project/phoebe2/pull/1033 and reported in https://github.com/phoebe-project/phoebe2/discussions/1042

These changes should then also be pushed back to the `distl` and `unitsiau2015` repos.