### PR TITLE
fix parse_solver_times compat with numpy updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ CHANGELOG
 
 ### 2.4.20
 
+* Fix parse_solver_times compatibility with numpy > 1.24. [#1056]
+
 ### 2.4.19
 
 * Remove unused passband files [#1045]

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -13390,7 +13390,7 @@ class Bundle(ParameterSet):
                 raise NotImplementedError("solver_times='{}' not implemented".format(solver_times))
 
             if return_as_dict:
-                if new_compute_times == []:
+                if len(new_compute_times) == 0:
                     if masked_times is None:
                         compute_times_per_ds[param.dataset] = _get_masked_times(self, param.dataset, [], 0.0, return_times_phases=False)
                     else:

--- a/tests/tests/test_solver_infra/test_solver_times.py
+++ b/tests/tests/test_solver_infra/test_solver_times.py
@@ -1,0 +1,17 @@
+import phoebe
+
+
+def test_parse_solver_times():
+    b = phoebe.default_binary()
+    b.add_dataset('lc', times=phoebe.linspace(0,1,301), compute_phases=phoebe.linspace(0,1,101))
+    b.set_value('mask_enabled', True)
+    b.set_value('mask_phases', [(-0.1, 0.1), (0.45,0.55)])
+
+    b.add_solver('optimizer.nelder_mead')
+    b.set_value('solver_times', 'times')
+    b.parse_solver_times()
+
+
+if __name__ == '__main__':
+    logger = phoebe.logger(clevel='INFO')
+    test_parse_solver_times()


### PR DESCRIPTION
This PR fixes an incompatibility between `b.parse_solver_times()` and numpy 1.25+.

Fixes #1054