### PR TITLE
2.4.20 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.4.20
+
 ### 2.4.19
 
 * Remove unused passband files [#1045]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ CHANGELOG
 
 ### 2.4.20
 
+* Fix parse_solver_times compatibility with numpy > 1.24. [#1056]
+
 ### 2.4.19
 
 * Remove unused passband files [#1045]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ CHANGELOG
 
 * Fix parse_solver_times compatibility with numpy > 1.24. [#1056]
 
+* Update crimpl to allow custom MPI paths on the server and to use conda-forge as the default conda channel to avoid the need to agree to terms of the default channel. [#1055]
+
 ### 2.4.19
 
 * Remove unused passband files [#1045]

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -17,7 +17,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.4.19'
+__version__ = '2.4.20'
 
 import os as _os
 import sys as _sys

--- a/phoebe/dependencies/crimpl/remoteslurm.py
+++ b/phoebe/dependencies/crimpl/remoteslurm.py
@@ -401,7 +401,8 @@ class RemoteSlurmJob(_remotethread.RemoteThreadJob):
 class RemoteSlurmServer(_remotethread.RemoteThreadServer):
     _JobClass = RemoteSlurmJob
     def __init__(self, host, directory='~/crimpl', ssh='ssh', scp='scp',
-                 mail_user=None, server_name=None):
+                 mail_user=None, server_name=None, openmpi_path=None,
+                 openmpi_ld_library_path=None):
         """
         Connect to a remote server running a Slurm scheduler.
 
@@ -425,8 +426,15 @@ class RemoteSlurmServer(_remotethread.RemoteThreadServer):
         * `server_name` (string): name to assign to the server.  If not provided,
             will be adopted automatically from `host` and available from
             <RemoteSlurmServer.server_name>.
+        * `openmpi_path` (string, optional, default=None): path to the OpenMPI
+            installation on the remote server.  If provided, will be added to
+            the PATH environment variable when running scripts on the server.
+        * `openmpi_ld_library_path` (string, optional, default=None): path to
+            the OpenMPI library on the remote server.  If provided, will be added
+            to the LD_LIBRARY_PATH environment variable when running scripts
+            on the server.
         """
-        super().__init__(host, directory, ssh, scp)
+        super().__init__(host, directory, openmpi_path=openmpi_path, openmpi_ld_library_path=openmpi_ld_library_path, ssh=ssh, scp=scp)
         self.mail_user = mail_user
         self._dict_keys += ['mail_user']
 

--- a/phoebe/dependencies/crimpl/remotethread.py
+++ b/phoebe/dependencies/crimpl/remotethread.py
@@ -248,7 +248,8 @@ class RemoteThreadJob(_common.ServerJob):
 class RemoteThreadServer(_common.SSHServer):
     _JobClass = RemoteThreadJob
     def __init__(self, host, directory='~/crimpl', ssh='ssh', scp='scp',
-                 server_name=None):
+                 server_name=None, openmpi_path=None,
+                 openmpi_ld_library_path=None):
         """
         Connect to a remote server running jobs in threads (no scheduler).
 
@@ -269,6 +270,13 @@ class RemoteThreadServer(_common.SSHServer):
         * `server_name` (string): name to assign to the server.  If not provided,
             will be adopted automatically from `host` and available from
             <RemoteThreadServer.server_name>.
+        * `openmpi_path` (string, optional, default=None): path to the OpenMPI
+            installation on the remote server.  If provided, will be added to
+            the PATH environment variable when running scripts on the server.
+        * `openmpi_ld_library_path` (string, optional, default=None): path to
+            the OpenMPI library on the remote server.  If provided, will be added
+            to the LD_LIBRARY_PATH environment variable when running scripts
+            on the server.
         """
         self._host = host
 
@@ -277,10 +285,12 @@ class RemoteThreadServer(_common.SSHServer):
 
         self._ssh = ssh
         self._scp = scp
+        self._openmpi_path = openmpi_path
+        self._openmpi_ld_library_path = openmpi_ld_library_path
         self._server_name = server_name
 
-        super().__init__(directory)
-        self._dict_keys = ['host', 'directory', 'ssh', 'scp']
+        super().__init__(directory, openmpi_path=openmpi_path, openmpi_ld_library_path=openmpi_ld_library_path)
+        self._dict_keys = ['host', 'directory', 'ssh', 'scp', 'openmpi_path', 'openmpi_ld_library_path']
 
     @property
     def ssh(self):
@@ -304,6 +314,28 @@ class RemoteThreadServer(_common.SSHServer):
         * (string)
         """
         return self._host
+
+    @property
+    def openmpi_path(self):
+        """
+        Path to the OpenMPI installation on the remote server.
+
+        Returns
+        ----------
+        * (string or None): path to OpenMPI or None if not set.
+        """
+        return self._openmpi_path
+
+    @property
+    def openmpi_ld_library_path(self):
+        """
+        Path to the OpenMPI library on the remote server.
+
+        Returns
+        ----------
+        * (string or None): path to OpenMPI library or None if not set.
+        """
+        return self._openmpi_ld_library_path
 
     @property
     def _ssh_cmd(self):

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -13390,7 +13390,7 @@ class Bundle(ParameterSet):
                 raise NotImplementedError("solver_times='{}' not implemented".format(solver_times))
 
             if return_as_dict:
-                if new_compute_times == []:
+                if len(new_compute_times) == 0:
                     if masked_times is None:
                         compute_times_per_ds[param.dataset] = _get_masked_times(self, param.dataset, [], 0.0, return_times_phases=False)
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "phoebe"
-version = "2.4.19"
+version = "2.4.20"
 description = "PHOEBE: modeling and analysis of eclipsing binary stars"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/tests/test_solver_infra/test_solver_times.py
+++ b/tests/tests/test_solver_infra/test_solver_times.py
@@ -1,0 +1,17 @@
+import phoebe
+
+
+def test_parse_solver_times():
+    b = phoebe.default_binary()
+    b.add_dataset('lc', times=phoebe.linspace(0,1,301), compute_phases=phoebe.linspace(0,1,101))
+    b.set_value('mask_enabled', True)
+    b.set_value('mask_phases', [(-0.1, 0.1), (0.45,0.55)])
+
+    b.add_solver('optimizer.nelder_mead')
+    b.set_value('solver_times', 'times')
+    b.parse_solver_times()
+
+
+if __name__ == '__main__':
+    logger = phoebe.logger(clevel='INFO')
+    test_parse_solver_times()


### PR DESCRIPTION
* Fix parse_solver_times compatibility with numpy > 1.24. [#1056]

* Update crimpl to allow custom MPI paths on the server and to use conda-forge as the default conda channel to avoid the need to agree to terms of the default channel. [#1055]