### PR TITLE
2.4.21 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ CHANGELOG
 * Improved description for fti_oversample parameter. [#1061]
 * Updated all http links to https. [#1062]
 * Catch ellc OSError. [#1063]
+* Fixes parse_solver_times regression introduced in 2.4.20. [#1067]
 
 ### 2.4.20
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ CHANGELOG
 * Updated all http links to https. [#1062]
 * Catch ellc OSError. [#1063]
 * Fixes parse_solver_times regression introduced in 2.4.20. [#1067]
+* Fixes differential_corrections solver when multiple compute options exist. [#1069]
 
 ### 2.4.20
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ CHANGELOG
 * Add a PHOEBE_TABLES_SERVER environment variable to allow overriding the URL of the queried tables server. [#1060]
 * Improved description for fti_oversample parameter. [#1061]
 * Updated all http links to https. [#1062]
+* Catch ellc OSError. [#1063]
 
 ### 2.4.20
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ CHANGELOG
 * Catch ellc OSError. [#1063]
 * Fixes parse_solver_times regression introduced in 2.4.20. [#1067]
 * Fixes differential_corrections solver when multiple compute options exist. [#1069]
+* Fixes crimpl issue with scp files from remote server. [#1074]
 
 ### 2.4.20
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ CHANGELOG
 
 ### 2.4.21
 
+* Add a PHOEBE_TABLES_SERVER environment variable to allow overriding the URL of the queried tables server. [#1060]
+
 ### 2.4.20
 
 * Fix parse_solver_times compatibility with numpy > 1.24. [#1056]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHOEBE 2.4
 ------------------------
 
-<p align="center"><a href="http://phoebe-project.org"><img src="./images/logo_blue.svg" alt="PHOEBE logo" width="160px" align="center"/></a></p>
+<p align="center"><a href="https://phoebe-project.org"><img src="./images/logo_blue.svg" alt="PHOEBE logo" width="160px" align="center"/></a></p>
 
 <pre align="center" style="text-align:center; font-family:monospace; margin: 30px">
   pip install phoebe
@@ -9,10 +9,10 @@ PHOEBE 2.4
 
 <p align="center">
   <a href="https://pypi.org/project/phoebe/"><img src="https://img.shields.io/badge/pip-phoebe-blue.svg"/></a>
-  <a href="http://phoebe-project.org/install"><img src="https://img.shields.io/badge/python-3.8+-blue.svg"/></a>
+  <a href="https://phoebe-project.org/install"><img src="https://img.shields.io/badge/python-3.8+-blue.svg"/></a>
   <a href="https://github.com/phoebe-project/phoebe2/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPL3-blue.svg"/></a>
   <a href="https://github.com/phoebe-project/phoebe2/actions/workflows/on_pr.yml?query=branch%3Amaster"><img src="https://github.com/phoebe-project/phoebe2/actions/workflows/on_pr.yml/badge.svg?branch=master"/></a>
-  <a href="http://phoebe-project.org/docs/2.4"><img src="https://github.com/phoebe-project/phoebe2-docs/actions/workflows/build-docs.yml/badge.svg?branch=2.4"/></a>
+  <a href="https://phoebe-project.org/docs/2.4"><img src="https://github.com/phoebe-project/phoebe2-docs/actions/workflows/build-docs.yml/badge.svg?branch=2.4"/></a>
 <br/>
   <a href="https://ui.adsabs.harvard.edu/abs/2016ApJS..227...29P"><img src="https://img.shields.io/badge/ApJS-Prsa+2016-lightgrey.svg"/></a>
   <a href="https://ui.adsabs.harvard.edu/abs/2018ApJS..237...26H"><img src="https://img.shields.io/badge/ApJS-Horvat+2018-lightgrey.svg"/></a>
@@ -21,7 +21,7 @@ PHOEBE 2.4
 </p>
 
 <p align="center">
-  <a href="http://phoebe-project.org"><img src="./images/console.gif" alt="Console Animation" width="600px" align="center"/></a>
+  <a href="https://phoebe-project.org"><img src="./images/console.gif" alt="Console Animation" width="600px" align="center"/></a>
 </p>
 
 
@@ -30,13 +30,13 @@ INTRODUCTION
 
 PHOEBE stands for PHysics Of Eclipsing BinariEs. PHOEBE is pronounced [fee-bee](https://www.merriam-webster.com/dictionary/phoebe?pronunciation&lang=en_us&file=phoebe01.wav).
 
-PHOEBE 2 is a rewrite of the original PHOEBE code. For most up-to-date information please refer to the PHOEBE project webpage: [http://phoebe-project.org](http://phoebe-project.org)
+PHOEBE 2 is a rewrite of the original PHOEBE code. For most up-to-date information please refer to the PHOEBE project webpage: [https://phoebe-project.org](https://phoebe-project.org)
 
-PHOEBE 2.0 is described by the release paper published in the Astrophysical Journal Supplement, [Prša et al. (2016, ApJS 227, 29)](https://ui.adsabs.harvard.edu/#abs/2016ApJS..227...29P).  The addition of support for misaligned stars in version 2.1 is described in [Horvat et al. (2018, ApJS 237, 26)](https://ui.adsabs.harvard.edu/#abs/2018ApJS..237...26H).  Interstellar extinction and support for Python 3 was added in version 2.2 and described in [Jones et al. (2020, ApJS 247, 63)](https://ui.adsabs.harvard.edu/abs/2020ApJS..247...63J).  Inclusion of a general framework for solving the inverse problem as well as support for the [web and desktop clients](http://phoebe-project.org/clients) was introduced in version 2.3 as described in [Conroy et al. (2020, ApJS 250, 34)](https://ui.adsabs.harvard.edu/abs/2020ApJS..250...34C), which also removes support for Python 2.  PHOEBE 2.4 improves on the geometry and ebai estimators, updates gaussian processes to use either scikit-learn or celerite2, and adds support for submitting compute or solver runs on external servers.  These updates and fitting "best practices" will be discussed in Kochoska et al., in prep.
+PHOEBE 2.0 is described by the release paper published in the Astrophysical Journal Supplement, [Prša et al. (2016, ApJS 227, 29)](https://ui.adsabs.harvard.edu/#abs/2016ApJS..227...29P).  The addition of support for misaligned stars in version 2.1 is described in [Horvat et al. (2018, ApJS 237, 26)](https://ui.adsabs.harvard.edu/#abs/2018ApJS..237...26H).  Interstellar extinction and support for Python 3 was added in version 2.2 and described in [Jones et al. (2020, ApJS 247, 63)](https://ui.adsabs.harvard.edu/abs/2020ApJS..247...63J).  Inclusion of a general framework for solving the inverse problem as well as support for the [web and desktop clients](https://phoebe-project.org/clients) was introduced in version 2.3 as described in [Conroy et al. (2020, ApJS 250, 34)](https://ui.adsabs.harvard.edu/abs/2020ApJS..250...34C), which also removes support for Python 2.  PHOEBE 2.4 improves on the geometry and ebai estimators, updates gaussian processes to use either scikit-learn or celerite2, and adds support for submitting compute or solver runs on external servers.  These updates and fitting "best practices" will be discussed in Kochoska et al., in prep.
 
 PHOEBE 2 is released under the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.en.html).
 
-The source code is available for download from the [PHOEBE project homepage](http://phoebe-project.org) and from [github](https://github.com/phoebe-project/phoebe2).
+The source code is available for download from the [PHOEBE project homepage](https://phoebe-project.org) and from [github](https://github.com/phoebe-project/phoebe2).
 
 The development of PHOEBE 2 is funded in part by [NSF grant #1517474](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1517474), [NSF grant #1909109](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1909109) and [NASA 17-ADAP17-68](https://ui.adsabs.harvard.edu/abs/2017adap.prop...68P).
 
@@ -58,7 +58,7 @@ To install PHOEBE 2 from the source locally, go to the `phoebe2/` directory and 
 
     pip install .
 
-Note that as of the 2.4.16 release, PHOEBE requires Python 3.8 or later.  For further details on pre-requisites consult the [PHOEBE project webpage](http://phoebe-project.org/install/2.4).
+Note that as of the 2.4.16 release, PHOEBE requires Python 3.8 or later.  For further details on pre-requisites consult the [PHOEBE project webpage](https://phoebe-project.org/install/2.4).
 
 
 GETTING STARTED
@@ -70,9 +70,9 @@ PHOEBE 2 has a fairly steep learning curve. To start PHOEBE from python, issue:
     >>> import phoebe
     >>>
 
-As of the 2.3 release, PHOEBE also includes a desktop and web client user-interface which is installed independently of the python package here.  See the [phoebe2-ui repository](https://github.com/phoebe-project/phoebe2-ui) and [phoebe-project.org/clients](http://phoebe-project.org/clients) for more details.
+As of the 2.3 release, PHOEBE also includes a desktop and web client user-interface which is installed independently of the python package here.  See the [phoebe2-ui repository](https://github.com/phoebe-project/phoebe2-ui) and [phoebe-project.org/clients](https://phoebe-project.org/clients) for more details.
 
-To understand how to use PHOEBE, please consult the [tutorials, scripts and manuals](http://phoebe-project.org/docs/2.4/) hosted on the PHOEBE webpage.
+To understand how to use PHOEBE, please consult the [tutorials, scripts and manuals](https://phoebe-project.org/docs/2.4/) hosted on the PHOEBE webpage.
 
 
 CHANGELOG
@@ -82,6 +82,7 @@ CHANGELOG
 
 * Add a PHOEBE_TABLES_SERVER environment variable to allow overriding the URL of the queried tables server. [#1060]
 * Improved description for fti_oversample parameter. [#1061]
+* Updated all http links to https. [#1062]
 
 ### 2.4.20
 
@@ -380,8 +381,8 @@ CHANGELOG
 
 ### 2.3.30 - ld_coeffs fitting bugfix
 
-* all fitting ld_coeffs.  Each coefficient is referenced by index and can be fit or have distributions attached independently.  See [tutorial](http://phoebe-project.org/docs/latest/tutorials/fitting_ld_coeffs) for more details.
-* also fixes support for [custom constraints](http://phoebe-project.org/docs/latest/tutorials/constraints_custom) which can be used to link ld_coeffs between datasets of the same passband, for example.
+* all fitting ld_coeffs.  Each coefficient is referenced by index and can be fit or have distributions attached independently.  See [tutorial](https://phoebe-project.org/docs/latest/tutorials/fitting_ld_coeffs) for more details.
+* also fixes support for [custom constraints](https://phoebe-project.org/docs/latest/tutorials/constraints_custom) which can be used to link ld_coeffs between datasets of the same passband, for example.
 
 ### 2.3.29 - adopt_solution bugfix
 
@@ -523,7 +524,7 @@ CHANGELOG
 
 * Add support for inverse problem solvers, including "estimators", "optimizers", and "samplers"
 * Add support for attaching distributions (as [distl](https://github.com/kecnry/distl) objects) to parameters, including priors and posteriors.
-* Add support for [web and desktop clients](http://phoebe-project.org/clients) via a light-weight built in `phoebe-server`.
+* Add support for [web and desktop clients](https://phoebe-project.org/clients) via a light-weight built in `phoebe-server`.
 * Removed support for Python 2 (now requires Python 3.6+)
 * Implement optional gaussian processes for light curves
 * Implement phase-masking
@@ -736,4 +737,4 @@ an envelope were being raised before all constraints could resolve successfully.
 QUESTIONS? SUGGESTIONS? CONCERNS?
 ---------------------------------
 
-Contact us! Issues and feature requests should be submitted directly through GitHub's [issue tracker](https://github.com/phoebe-project/phoebe2/issues).  Additional questions or feature requests should be submitted via [GitHub PHOEBE2 discussions](https://github.com/phoebe-project/phoebe2/discussions) or [GitHub PHOEBE2-UI discussions](https://github.com/phoebe-project/phoebe2-ui/discussions). We are eager to hear from you, so do not hesitate to [contact us](http://phoebe-project.org/help/contact)!
+Contact us! Issues and feature requests should be submitted directly through GitHub's [issue tracker](https://github.com/phoebe-project/phoebe2/issues).  Additional questions or feature requests should be submitted via [GitHub PHOEBE2 discussions](https://github.com/phoebe-project/phoebe2/discussions) or [GitHub PHOEBE2-UI discussions](https://github.com/phoebe-project/phoebe2-ui/discussions). We are eager to hear from you, so do not hesitate to [contact us](https://phoebe-project.org/help/contact)!

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ To understand how to use PHOEBE, please consult the [tutorials, scripts and manu
 CHANGELOG
 ----------
 
+### 2.4.21
+
 ### 2.4.20
 
 * Fix parse_solver_times compatibility with numpy > 1.24. [#1056]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ CHANGELOG
 ### 2.4.21
 
 * Add a PHOEBE_TABLES_SERVER environment variable to allow overriding the URL of the queried tables server. [#1060]
+* Improved description for fti_oversample parameter. [#1061]
 
 ### 2.4.20
 

--- a/client-server/phoebe-server
+++ b/client-server/phoebe-server
@@ -1131,7 +1131,7 @@ def ui_file(static_file=None, bootstrap_file=None, fa_file=None):
 @app.route('/<path:path>', methods=['GET', 'POST'])
 def ui(path=''):
     if _ui_path is None:
-        return redirect('http://ui.phoebe-project.org/'+str(path)+'?'+str(request.query_string))
+        return redirect('https://ui.phoebe-project.org/'+str(path)+'?'+str(request.query_string))
 
     base, fname = os.path.dirname(_ui_path), os.path.basename(_ui_path)
     return send_from_directory(base, fname)

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -8,11 +8,11 @@ Available environment variables:
 * PHOEBE_PBDIR (directory to search for passbands, in addition to phoebe.list_passband_directories())
 * PHOEBE_DOWNLOAD_PASSBAND_DEFAULTS_GZIPPED=TRUE/FALSE (whether to download gzipped version of passbands by default.  Defaults to False.  Note that gzipped files take longer to load and will increase time for import, but take significantly less disk-space.)
 * PHOEBE_DOWNLOAD_PASSBAND_DEFAULTS_CONTENT (default content, comma separated for list.  Defaults to 'all')
+* PHOEBE_TABLES_SERVER=STR (URL of tables server to query for passband files.  Default to official tables server)
 * PHOEBE_UPDATE_PASSBAND_IGNORE_VERSION=TRUE/FALSE (update passbands that need new content even if the online version is newer than the installed version.  Defaults to False.)
 * PHOEBE_ENABLE_MPI=TRUE/FALSE (whether to use internal parallelization: defaults to True if within mpirun, otherwise False, can override in python with phoebe.mpi.on() and phoebe.mpi.off())
 * PHOEBE_MPI_NPROCS=INT (number of procs to spawn in mpi is enabled but not running within mpirun: defaults to 4, only applicable if not within mpirun and PHOEBE_ENABLE_MPI=TRUE or phoebe.mpi.on() called, can override in python by passing nprocs to phoebe.mpi.on() or by setting phoebe.mpi.nprocs)
 * PHOEBE_MULTIPROC_NPROCS=INT (number of proces to use within multiprocessing.  Multiprocessing is used for solver that support it and when sampling over a distribution in run_compute if MPI is not in use.  Set to 0 to disable multiprocessing and force serial.  Defaults to number of CPUs available.)
-* PHOEBE_PBDIR (directory to search for passbands, in addition to phoebe.list_passband_directories())
 * PHOEBE_DEVEL=TRUE/FALSE enable developer mode by default
 
 """

--- a/phoebe/__init__.py
+++ b/phoebe/__init__.py
@@ -17,7 +17,7 @@ Available environment variables:
 
 """
 
-__version__ = '2.4.20'
+__version__ = '2.4.21'
 
 import os as _os
 import sys as _sys

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -39,7 +39,7 @@ logger.addHandler(logging.NullHandler())
 
 # define the URL to query for online passbands.  See tables.phoebe-project.org
 # repo for the source-code of the server
-_url_tables_server = 'http://tables.phoebe-project.org'
+_url_tables_server = os.getenv('PHOEBE_TABLES_SERVER', 'http://tables.phoebe-project.org')
 # comment out the following line if testing tables.phoebe-project.org server locally:
 # _url_tables_server = 'http://localhost:5555'
 
@@ -73,8 +73,6 @@ if not os.path.exists(_pbdir_local):
 
 _pbdir_env = os.getenv('PHOEBE_PBDIR', None)
 
-
-_pbdir_env = os.getenv('PHOEBE_PBDIR', None)
 
 def _dict_without_keys(d, skip_keys=[]):
     return {k:v for k,v in d.items() if k not in skip_keys}

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -39,7 +39,7 @@ logger.addHandler(logging.NullHandler())
 
 # define the URL to query for online passbands.  See tables.phoebe-project.org
 # repo for the source-code of the server
-_url_tables_server = os.getenv('PHOEBE_TABLES_SERVER', 'http://tables.phoebe-project.org')
+_url_tables_server = os.getenv('PHOEBE_TABLES_SERVER', 'https://tables.phoebe-project.org')
 # comment out the following line if testing tables.phoebe-project.org server locally:
 # _url_tables_server = 'http://localhost:5555'
 
@@ -2575,7 +2575,7 @@ def download_passband(passband, content=None, local=True, gzipped=None):
     <phoebe.atmospheres.passbands.download_passband>.
 
     Download and install a given passband from
-    http://tables.phoebe-project.org.
+    the tables server (https://tables.phoebe-project.org by default).
 
     The local and global installation directories can be listed by calling
     <phoebe.atmospheres.passbands.list_passband_directories>.  The local
@@ -2679,7 +2679,7 @@ def list_passband_online_history(passband, since_installed=True):
     try:
         resp = urlopen(url, timeout=3)
     except Exception as err:
-        msg = "connection to online passbands at {} could not be established.  Check your internet connection or try again later.  If the problem persists and you're using a Mac, you may need to update openssl (see http://phoebe-project.org/help/faq).".format(_url_tables_server)
+        msg = "connection to online passbands at {} could not be established.  Check your internet connection or try again later.  If the problem persists and you're using a Mac, you may need to update openssl (see https://phoebe-project.org/help/faq).".format(_url_tables_server)
         msg += " Original error from urlopen: {} {}".format(err.__class__.__name__, str(err))
 
         logger.warning(msg)
@@ -2816,7 +2816,7 @@ def update_passband(passband, local=True, content=None, gzipped=None):
     <phoebe.atmospheres.passbands.update_passband>.
 
     Download and install updates for a single passband from
-    http://tables.phoebe-project.org, retrieving
+    the tables server (https://tables.phoebe-project.org by default), retrieving
     the same content as in the installed passband.
 
     This will install into the directory dictated by `local`, regardless of the
@@ -2884,7 +2884,7 @@ def update_all_passbands(local=True, content=None):
     <phoebe.atmospheres.passbands.update_all_passbands>.
 
     Download and install updates for all passbands from
-    http://tables.phoebe-project.org, retrieving
+    the tables server (https://tables.phoebe-project.org by default), retrieving
     the same content as in the installed passbands.
 
     This will install into the directory dictated by `local`, regardless of the
@@ -3032,7 +3032,7 @@ def list_online_passbands(refresh=False, full_dict=False, skip_keys=[], repeat_e
     <phoebe.atmospheres.passbands.list_online_passbands>.
 
     List all passbands available for download from
-    http://tables.phoebe-project.org.
+    the tables server (https://tables.phoebe-project.org by default).
 
     Arguments
     ---------
@@ -3069,7 +3069,7 @@ def list_online_passbands(refresh=False, full_dict=False, skip_keys=[], repeat_e
                 resp = urlopen(url, timeout=3)
             except Exception as err:
                 _online_passband_failedtries += 1
-                msg = "Connection to online passbands at {} could not be established.  Check your internet connection or try again later (can manually call phoebe.list_online_passbands(refresh=True) to retry).  If the problem persists and you're using a Mac, you may need to update openssl (see http://phoebe-project.org/help/faq).".format(_url_tables_server, _online_passband_failedtries)
+                msg = "Connection to online passbands at {} could not be established.  Check your internet connection or try again later (can manually call phoebe.list_online_passbands(refresh=True) to retry).  If the problem persists and you're using a Mac, you may need to update openssl (see https://phoebe-project.org/help/faq).".format(_url_tables_server, _online_passband_failedtries)
                 msg += " Original error from urlopen: {} {}".format(err.__class__.__name__, str(err))
 
                 logger.warning("(Attempt {} of 3): ".format(_online_passband_failedtries)+msg)
@@ -3127,7 +3127,7 @@ def get_passband(passband, content=None, reload=False, update_if_necessary=False
     will be downloaded and installed locally.  If the installed passband does
     not have the necessary tables to match `content` then an attempt will be
     made to download the necessary additional tables from
-    http://tables.phoebe-project.org
+    the tables server (https://tables.phoebe-project.org by default)
     as long as the timestamps match the local version.  If the online version
     includes other version updates, then an error will be
     raised suggesting to call <phoebe.atmospheres.passbands.update_passband>

--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -45,7 +45,7 @@ else:
 
 try:
     import ellc
-except ImportError:
+except Exception:
     _use_ellc = False
 else:
     _use_ellc = True

--- a/phoebe/dependencies/ligeor/eclipse/eb_params.py
+++ b/phoebe/dependencies/ligeor/eclipse/eb_params.py
@@ -162,7 +162,7 @@ class EbParams(object):
         '''
         try:
             import ellc
-        except:
+        except Exception:
             raise ImportError('ellc is required for parameter refinement, please install it before running this step.')
         
         def wrap_around_05(phases):

--- a/phoebe/dynamics/nbody.py
+++ b/phoebe/dynamics/nbody.py
@@ -23,7 +23,7 @@ else:
 
 try:
     import reboundx
-except (ImportError, OSError):
+except Exception:
     _can_reboundx = False
 else:
     _can_reboundx = True

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -5386,7 +5386,7 @@ class Bundle(ParameterSet):
                          'Skilling (2006)': 'https://projecteuclid.org/euclid.ba/1340370944',
                          'Foreman-Mackey et al. (2017)': 'https://ui.adsabs.harvard.edu/abs/2017AJ....154..220F',
                          'Prsa et al. (2008)': 'https://ui.adsabs.harvard.edu/abs/2008ApJ...687..542P',
-                         'Kochoska et al. (in prep)': 'http://phoebe-project.org/publications/2022Kochoska+',
+                         'Kochoska et al. (in prep)': 'https://phoebe-project.org/publications/2022Kochoska+',
                          'scikit-learn': 'https://scikit-learn.org/stable/about.html#citing-scikit-learn',
                         }
 

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -13390,16 +13390,16 @@ class Bundle(ParameterSet):
                 raise NotImplementedError("solver_times='{}' not implemented".format(solver_times))
 
             if return_as_dict:
-                if len(new_compute_times) == 0:
-                    if masked_times is None:
-                        compute_times_per_ds[param.dataset] = _get_masked_times(self, param.dataset, [], 0.0, return_times_phases=False)
-                    else:
-                        compute_times_per_ds[param.dataset] = masked_times
-                elif new_compute_times is None:
+                if new_compute_times is None:
                     if masked_compute_times is None:
                         compute_times_per_ds[param.dataset] = ds_ps.get_value(qualifier='compute_times', unit=u.d, **_skip_filter_checks)
                     else:
                         compute_times_per_ds[param.dataset] = masked_compute_times
+                elif len(new_compute_times) == 0:
+                    if masked_times is None:
+                        compute_times_per_ds[param.dataset] = _get_masked_times(self, param.dataset, [], 0.0, return_times_phases=False)
+                    else:
+                        compute_times_per_ds[param.dataset] = masked_times
                 else:
                     compute_times_per_ds[param.dataset] = new_compute_times
 

--- a/phoebe/lib/wd_atm.h
+++ b/phoebe/lib/wd_atm.h
@@ -6,7 +6,7 @@
     * atmx.f
     * planckint.f
 
-  from http://phoebe-project.org/1.0/releases/wd_2007-08-15_phoebe.tar.gz
+  from https://phoebe-project.org/1.0/releases/wd_2007-08-15_phoebe.tar.gz
 
   or combined in atomcof.f in phoebe pre v2
 

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -48,7 +48,7 @@ def phoebe(**kwargs):
     pre-requisites are required.
 
     When using this backend, please see the
-    http://phoebe-project.org/publications and cite
+    https://phoebe-project.org/publications and cite
     the appropriate references.
 
     See also:
@@ -196,7 +196,7 @@ def phoebe(**kwargs):
 def legacy(**kwargs):
     """
     Create a <phoebe.parameters.ParameterSet> for compute options for the
-    [PHOEBE 1.0 legacy](http://phoebe-project.org/1.0) backend.
+    [PHOEBE 1.0 legacy](https://phoebe-project.org/1.0) backend.
 
     See also:
     * <phoebe.frontend.bundle.Bundle.export_legacy>
@@ -206,7 +206,7 @@ def legacy(**kwargs):
     to compute radial velocities and light curves for binary systems
     (>2 stars not supported).  The code is available here:
 
-    http://phoebe-project.org/1.0
+    https://phoebe-project.org/1.0
 
     PHOEBE 1.0 and the 'phoebeBackend' python interface must be installed
     and available on the system in order to use this plugin.

--- a/phoebe/parameters/compute.py
+++ b/phoebe/parameters/compute.py
@@ -180,7 +180,7 @@ def phoebe(**kwargs):
     # rv_dep kind
     # params += [ChoiceParameter(qualifier='lc_method', copy_for = {'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('lc_method', 'numerical'), choices=['numerical', 'analytical'] if conf.devel else ['numerical'], advanced=True, description='Method to use for computing LC fluxes')]
     params += [ChoiceParameter(qualifier='fti_method', copy_for = {'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_method', 'none'), choices=['none', 'oversample'], description='How to handle finite-time integration (when non-zero exptime)')]
-    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration')]
+    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration (when non-zero exptime)')]
 
     params += [ChoiceParameter(qualifier='rv_method', copy_for={'component': {'kind': 'star'}, 'dataset': {'kind': 'rv'}}, component='_default', dataset='_default', value=kwargs.get('rv_method', 'flux-weighted'), choices=['flux-weighted', 'dynamical'], description='Method to use for computing RVs (must be flux-weighted for Rossiter-McLaughlin effects)')]
     params += [BoolParameter(visible_if='rv_method:flux-weighted', qualifier='rv_grav', copy_for={'component': {'kind': 'star'}, 'dataset': {'kind': 'rv'}}, component='_default', dataset='_default', value=kwargs.get('rv_grav', False), description='Whether gravitational redshift effects are enabled for RVs')]
@@ -290,7 +290,7 @@ def legacy(**kwargs):
                                value=kwargs.get('rv_method', 'flux-weighted'), choices=['flux-weighted', 'dynamical'], description='Method to use for computing RVs (must be flux-weighted for Rossiter-McLaughlin)')]
 
     params += [ChoiceParameter(qualifier='fti_method', copy_for = {'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_method', 'none'), choices=['none', 'oversample'], description='How to handle finite-time integration (when non-zero exptime)')]
-    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration')]
+    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration (when non-zero exptime)')]
 
 
     return ParameterSet(params)
@@ -414,7 +414,7 @@ def photodynam(**kwargs):
     params += [ChoiceParameter(qualifier='irrad_method', value=kwargs.get('irrad_method', 'none'), choices=['none'], description='Which method to use to handle all irradiation effects (ellc does not support irradiation)')]
 
     params += [ChoiceParameter(qualifier='fti_method', copy_for = {'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_method', 'none'), choices=['none', 'oversample'], description='How to handle finite-time integration (when non-zero exptime)')]
-    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration')]
+    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration (when non-zero exptime)')]
 
 
     return ParameterSet(params)
@@ -560,7 +560,7 @@ def jktebop(**kwargs):
     params += [ChoiceParameter(qualifier='irrad_method', value=kwargs.get('irrad_method', 'biaxial-spheroid'), choices=['none', 'biaxial-spheroid'], description='Which method to use to handle all irradiation effects')]
 
     params += [ChoiceParameter(qualifier='fti_method', copy_for = {'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_method', 'none'), choices=['none', 'oversample'], description='How to handle finite-time integration (when non-zero exptime)')]
-    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration')]
+    params += [IntParameter(visible_if='fti_method:oversample', qualifier='fti_oversample', copy_for={'kind': ['lc'], 'dataset': '*'}, dataset='_default', value=kwargs.get('fti_oversample', 5), limits=(1,None), default_unit=u.dimensionless_unscaled, description='Number of times to sample per-datapoint for finite-time integration (when non-zero exptime)')]
 
     return ParameterSet(params)
 

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -2051,7 +2051,7 @@ class ParameterSet(object):
         the notebook execution if blocking.
 
         To more information or to install the desktop-client, see
-        http://phoebe-project.org/clients
+        https://phoebe-project.org/clients
 
         See also:
         * <phoebe.frontend.bundle.Bundle.ui_figures>

--- a/phoebe/solverbackends/solverbackends.py
+++ b/phoebe/solverbackends/solverbackends.py
@@ -646,11 +646,12 @@ class Lc_GeometryBackend(BaseSolverBackend):
         if fit_eclipses:
             try:
                 import ellc
+            except Exception:
+                raise ImportError('ellc needs to be installed to refine the fit when fit_eclipses = True')
+            else:
                 rratio_param = orbit_ps.get_parameter(qualifier='requivratio', **_skip_filter_checks)
                 incl_param = orbit_ps.get_parameter(qualifier='incl@binary', **_skip_filter_checks)
                 fitted_params += [rratio_param, incl_param]
-            except:
-                raise ImportError('ellc needs to be installed to refine the fit when fit_eclipses = True')
 
         eb_params = ligeor.eclipse.EbParams(eclipse_dict, fit_eclipses=fit_eclipses)
         t0_near_times = kwargs.get('t0_near_times', True)

--- a/phoebe/solverbackends/solverbackends.py
+++ b/phoebe/solverbackends/solverbackends.py
@@ -2450,7 +2450,7 @@ class Differential_CorrectionsBackend(BaseSolverBackend):
                 obs_baseline = np.append(obs_baseline, interp_model)
             return xi, obs_baseline
 
-        baseline_model = b_solver.run_compute(model='baseline', overwrite=True)
+        baseline_model = b_solver.run_compute(compute=compute, model='baseline', overwrite=True)
         xi, obs_baseline = _get_residuals_and_interp_model(b_solver, 'baseline', obs_params)
         if _use_progressbar:
             _dc_pbar.update(1)
@@ -2464,7 +2464,7 @@ class Differential_CorrectionsBackend(BaseSolverBackend):
             # numerical derivatives:
             if deriv_method == 'asymmetric':
                 param.set_value(value=value+step)
-                upper_model = b_solver.run_compute(model='upper', overwrite=True)
+                upper_model = b_solver.run_compute(compute=compute, model='upper', overwrite=True)
                 resid_upper, obs_upper = _get_residuals_and_interp_model(b_solver, 'upper', obs_params)
                 if _use_progressbar:
                     _dc_pbar.update(1)
@@ -2472,13 +2472,13 @@ class Differential_CorrectionsBackend(BaseSolverBackend):
 
             elif deriv_method == 'symmetric':
                 param.set_value(value=value+step/2)
-                upper_model = b_solver.run_compute(model='upper', overwrite=True)
+                upper_model = b_solver.run_compute(compute=compute, model='upper', overwrite=True)
                 resid_upper, obs_upper = _get_residuals_and_interp_model(b_solver, 'upper', obs_params)
                 if _use_progressbar:
                     _dc_pbar.update(1)
 
                 param.set_value(value=value-step/2)
-                lower_model = b_solver.run_compute(model='lower', overwrite=True)
+                lower_model = b_solver.run_compute(compute=compute, model='lower', overwrite=True)
                 resid_lower, obs_lower = _get_residuals_and_interp_model(b_solver, 'lower', obs_params)
                 if _use_progressbar:
                     _dc_pbar.update(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,9 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "http://phoebe-project.org"
+homepage = "https://phoebe-project.org"
 repository = "https://github.com/phoebe-project/phoebe2"
-documentation = "http://phoebe-project.org/docs"
+documentation = "https://phoebe-project.org/docs"
 
 [build-system]
 requires = ["setuptools", "numpy", "wheel"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@
 
 [project]
 name = "phoebe"
-version = "2.4.20"
+version = "2.4.21"
 description = "PHOEBE: modeling and analysis of eclipsing binary stars"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
* Add a PHOEBE_TABLES_SERVER environment variable to allow overriding the URL of the queried tables server. [#1060]
* Improved description for fti_oversample parameter. [#1061]
* Updated all http links to https. [#1062]
* Catch ellc OSError. [#1063]
* Fixes parse_solver_times regression introduced in 2.4.20. [#1067]
* Fixes differential_corrections solver when multiple compute options exist. [#1069]
* Fixes crimpl issue with scp files from remote server. [#1074]