### PR TITLE
Fixes DC on SB1 data.

### DIFF
--- a/phoebe/solverbackends/solverbackends.py
+++ b/phoebe/solverbackends/solverbackends.py
@@ -2423,7 +2423,13 @@ class Differential_CorrectionsBackend(BaseSolverBackend):
         datasets_enabled = b.filter(dataset=datasets_enabled, kind=['lc', 'rv'], context='dataset', **_skip_filter_checks).datasets
 
         # need to ensure we access the obs and sigma arrays in the same order
+        # and only include non-empty observations that will contribute to residuals
         obs_params = b.filter(qualifier=['fluxes', 'rvs'], dataset=datasets_enabled, context='dataset', **_skip_filter_checks).to_list()
+        obs_params = [p for p in obs_params if p.component != '_default' and len(p.get_value())]
+
+        if not len(obs_params):
+            raise ValueError("no observations found in enabled lc/rv datasets for differential corrections")
+
         obs_data = np.concatenate([p.get_value() for p in obs_params])
         obs_sigmas = np.concatenate([b.get_parameter(qualifier=['sigmas'], dataset=p.dataset, component=p.component, context='dataset', **_skip_filter_checks).get_value() for p in obs_params])
 
@@ -2444,6 +2450,8 @@ class Differential_CorrectionsBackend(BaseSolverBackend):
             obs_baseline = np.array([])
             for p in obs_params:
                 if p.component == '_default':
+                    continue
+                if not len(p.get_value()):
                     continue
                 resid, interp_model = b_solver.calculate_residuals(model=model, dataset=p.dataset, component=p.component, return_interp_model=True, as_quantity=False)
                 xi = np.append(xi, resid)

--- a/tests/tests/test_optimizers/test_dc_rv.py
+++ b/tests/tests/test_optimizers/test_dc_rv.py
@@ -1,0 +1,86 @@
+import numpy as np
+import phoebe
+import pytest
+
+
+def _build_dc_bundle(times_primary, rvs_primary, sigmas_primary,
+                     times_secondary, rvs_secondary, sigmas_secondary):
+    b = phoebe.default_binary()
+    b.add_solver('differential_corrections', solver='dc')
+
+    b.add_dataset(
+        kind='rv',
+        dataset='rv01',
+        compute_phases=np.linspace(0.0, 1.0, 31),
+        times={'primary': times_primary, 'secondary': times_secondary},
+        rvs={'primary': rvs_primary, 'secondary': rvs_secondary},
+        sigmas={'primary': sigmas_primary, 'secondary': sigmas_secondary},
+    )
+
+    b.set_value(
+        twig='fit_parameters@dc@differential_corrections@solver',
+        value=['incl@binary'],
+    )
+    b.set_value(
+        twig='steps@dc@differential_corrections@solver',
+        value={'incl@binary': 0.01},
+    )
+
+    return b
+
+
+@pytest.mark.parametrize(
+    'case, times_primary, rvs_primary, sigmas_primary, times_secondary, rvs_secondary, sigmas_secondary, should_raise',
+    [
+        ('sb0', [], [], [], [], [], [], True),
+        (
+            'sb1_primary',
+            np.linspace(0.0, 1.0, 20),
+            20.0 * np.sin(2.0 * np.pi * np.linspace(0.0, 1.0, 20)),
+            np.ones(20),
+            [],
+            [],
+            [],
+            False,
+        ),
+        (
+            'sb1_secondary',
+            [],
+            [],
+            [],
+            np.linspace(0.0, 1.0, 20),
+            -20.0 * np.sin(2.0 * np.pi * np.linspace(0.0, 1.0, 20)),
+            np.ones(20),
+            False,
+        ),
+        (
+            'sb2',
+            np.linspace(0.0, 1.0, 20),
+            20.0 * np.sin(2.0 * np.pi * np.linspace(0.0, 1.0, 20)),
+            np.ones(20),
+            np.linspace(0.0, 1.0, 20),
+            -20.0 * np.sin(2.0 * np.pi * np.linspace(0.0, 1.0, 20)),
+            np.ones(20),
+            False,
+        ),
+    ],
+)
+def test_dc_rv_sb0_sb1_sb2(case, times_primary, rvs_primary, sigmas_primary,
+                           times_secondary, rvs_secondary, sigmas_secondary, should_raise):
+    b = _build_dc_bundle(
+        times_primary=times_primary,
+        rvs_primary=rvs_primary,
+        sigmas_primary=sigmas_primary,
+        times_secondary=times_secondary,
+        rvs_secondary=rvs_secondary,
+        sigmas_secondary=sigmas_secondary,
+    )
+
+    if should_raise:
+        with pytest.raises(
+            ValueError,
+            match='no observations found in enabled lc/rv datasets for differential corrections',
+        ):
+            b.run_solver(solver='dc', progressbar=False)
+    else:
+        b.run_solver(solver='dc', progressbar=False)

--- a/tests/tests/test_t0s/test_t0s.py
+++ b/tests/tests/test_t0s/test_t0s.py
@@ -4,10 +4,9 @@
 import phoebe
 import pytest
 
-phoebe.interactive_on()
-
 
 def test_binary(verbose=False):
+    phoebe.interactive_on()
     def assert_t0s(p1_t0_ref, p1_t0_supconj, p1_t0_perpass, tol=1e-4):
         # b.run_delayed_constraints()
 
@@ -81,6 +80,8 @@ def test_binary(verbose=False):
     p1_supconj = 0.418709
     p1_perpass = 0.0
     assert_t0s(p1_ref, p1_supconj, p1_perpass)
+
+    phoebe.reset_settings()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Differential corrections (DC) failed with a cryptic "model 'baseline' not found" when RV data were SB1 (either primary or secondary times/RVs/sigmas missing). This has now been fixed. We also explicitly check for *any* available data among the enabled datasets and raise an error if no data are found.

A pytest added that makes sure that DC now works for SB1 (both variants), SB2 and raises an error gracefully for SB0.