### PR TITLE
"Marcin bug" bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 /phoebe/atmospheres/tables/tmap*
 /phoebe/atmospheres/tables/tlusty
 /tests/tests/test_passbands/tables
-/tests/local
-/tests/benchmark
 MANIFEST
 *checkme*
 *_tmp*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /phoebe/atmospheres/tables/tmap*
 /phoebe/atmospheres/tables/tlusty
 /tests/tests/test_passbands/tables
+/tests/local
+/tests/benchmark
 MANIFEST
 *checkme*
 *_tmp*

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -1668,7 +1668,7 @@ class Passband:
                 ld_func=ld_func,
                 ld_coeffs=ld_coeffs,
                 intens_weighting=intens_weighting,
-                atm_extrapolation_method=atm_extrapolation_method,
+                atm_extrapolation_method=ld_extrapolation_method,
                 ld_extrapolation_method=ld_extrapolation_method
             )
 
@@ -1683,7 +1683,7 @@ class Passband:
                 ld_func=ld_func,
                 ld_coeffs=ld_coeffs,
                 intens_weighting=intens_weighting,
-                atm_extrapolation_method=atm_extrapolation_method,
+                atm_extrapolation_method=ld_extrapolation_method,
                 ld_extrapolation_method=ld_extrapolation_method
             ).get_interpolated_values()
 


### PR DESCRIPTION
Marcin discovered that extrapolation/blending can cause haywire intensities for high Teffs and low mus. This was the consequence of limb darkening extrapolation defaulting to ATM instead of LD extrapolation method, causing the intensities to go crazy. The fix is to use LD extrapolation instead of ATM extrapolation.