### PR TITLE
update b.references for 2.5 release and accompanying paper

### DIFF
--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -5486,10 +5486,7 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Skilling (2004)', 'nested sampling: dynesty solver backend')
                 recs = _add_reason(recs, 'Skilling (2006)', 'nested sampling: dynesty solver backend')
             elif solver_kind == 'differential_evolution':
-                recs = _add_reason(recs, 'Conroy et al. (2020)', 'differential_evolution solver introduced in PHOEBE')
                 recs = _add_reason(recs, 'numpy/scipy', '{} solver uses scipy.optimize.differential_evolution'.format(solver_kind))
-            elif solver_kind == 'differential_corrections':
-                recs = _add_reason(recs, 'Conroy et al. (2020)', 'differential_corrections solver introduced in PHOEBE')
 
 
         # check for presence of datasets that require PHOEBE releases
@@ -5521,15 +5518,15 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname == 'tmap_sdO':
                 recs = _add_reason(recs, 'Reindl et al. (2016)', 'TMAP atmosphere tables')
-                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'TMAP atmosphere tables included in PHOEBE')
             elif atmname in ['tmap_DA', 'tmap_DAO', 'tmap_DO']:
                 recs = _add_reason(recs, 'Reindl et al. (2023)', 'TMAP atmosphere tables')
-                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'TMAP atmosphere tables included in PHOEBE')
             elif atmname in ['extern_planckint', 'extern_atmx']:
                 recs = _add_reason(recs, 'Prsa & Zwitter (2005)', '{} atmosphere tables'.format(atmname))
             elif atmname == 'tremblay':
                 recs = _add_reason(recs, 'Tremblay et al. (2011, 2013)', 'Tremblay atmosphere tables')
-                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'Tremblay atmosphere tables included in PHOEBE')
 
 
         for atm_param in self.filter(qualifier='ld_coeffs_source', component=self.hierarchy.get_stars()).to_list():
@@ -5541,13 +5538,13 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname == 'tmap_sdO':
                 recs = _add_reason(recs, 'Reindl et al. (2016)', 'TMAP atmosphere tables')
-                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'TMAP atmosphere tables included in PHOEBE')
             elif atmname in ['tmap_DA', 'tmap_DAO', 'tmap_DO']:
                 recs = _add_reason(recs, 'Reindl et al. (2023)', 'TMAP atmosphere tables')
-                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'TMAP atmosphere tables included in PHOEBE')
             elif atmname == 'tremblay':
                 recs = _add_reason(recs, 'Tremblay et al. (2011, 2013)', 'Tremblay atmosphere tables')
-                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'Tremblay atmosphere tables included in PHOEBE')
 
         # cite extrapolation/blending methods when atmosphere grids are used off-grid
         for extrap_param in self.filter(qualifier=['atm_extrapolation_method', 'ld_extrapolation_method'], compute=computes).to_list():
@@ -5557,10 +5554,8 @@ class Bundle(ParameterSet):
                 
         # provide any references from features
         if len(self.filter(context='feature', kind='gp_sklearn').features):
-            recs = _add_reason(recs, 'Conroy et al. (2020)', 'sklearn GPs introduced in PHOEBE')
             recs = _add_reason(recs, 'scikit-learn', 'scikit-learn for gaussian processes')
         if len(self.filter(context='feature', kind='gp_celerite2').features):
-            recs = _add_reason(recs, 'Conroy et al. (2020)', 'celerite2 GPs introduced in PHOEBE')
             recs = _add_reason(recs, 'Foreman-Mackey et al., (2017)', 'celerite2 for gaussian processes')
         # provide references from dependencies
         recs = _add_reason(recs, 'numpy/scipy', 'numpy/scipy dependency within PHOEBE')

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -5431,7 +5431,6 @@ class Bundle(ParameterSet):
                          'Skilling (2006)': 'https://projecteuclid.org/euclid.ba/1340370944',
                          'Foreman-Mackey et al. (2017)': 'https://ui.adsabs.harvard.edu/abs/2017AJ....154..220F',
                          'Prsa et al. (2008)': 'https://ui.adsabs.harvard.edu/abs/2008ApJ...687..542P',
-                         'Kochoska et al.': 'https://phoebe-project.org/publications/2022Kochoska+',
                          'scikit-learn': 'https://scikit-learn.org/stable/about.html#citing-scikit-learn',
                          'Jones et al. (2026)': 'https://phoebe-project.org/publications/2026Jones+',
                         }
@@ -5469,10 +5468,8 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'astropy', 'astropy.timeseries for periodograms')
             elif solver_kind in ['lc_geometry', 'rv_geometry']:
                 recs = _add_reason(recs, 'Conroy et al. (2020)', '{} solver initially introduced in PHOEBE'.format(solver_kind))
-                recs = _add_reason(recs, 'Kochoska et al.', '{} solver updates'.format(solver_kind))
             elif solver_kind == 'ebai':
                 recs = _add_reason(recs, 'Conroy et al. (2020)', 'ebai solver initially introduced in PHOEBE')
-                recs = _add_reason(recs, 'Kochoska et al.', 'ebai solver updates')
                 ebai_method = self.get_value(qualifier='ebai_method', solver=solver, **_skip_filter_checks)
                 if solver_kind == 'knn':
                     recs = _add_reason(recs, 'scikit-learn', 'knn implementation for ebai solver')
@@ -5489,10 +5486,10 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Skilling (2004)', 'nested sampling: dynesty solver backend')
                 recs = _add_reason(recs, 'Skilling (2006)', 'nested sampling: dynesty solver backend')
             elif solver_kind == 'differential_evolution':
-                recs = _add_reason(recs, 'Kochoska et al.', 'differential_evolution solver introduced in PHOEBE')
-                recs = _add_reason('numpy/scipy', '{} solver uses scipy.optimize.differential_evolution'.format(solver_kind))
+                recs = _add_reason(recs, 'Conroy et al. (2020)', 'differential_evolution solver introduced in PHOEBE')
+                recs = _add_reason(recs, 'numpy/scipy', '{} solver uses scipy.optimize.differential_evolution'.format(solver_kind))
             elif solver_kind == 'differential_corrections':
-                recs = _add_reason(recs, 'Kochoska et al.', 'differential_corrections solver introduced in PHOEBE')
+                recs = _add_reason(recs, 'Conroy et al. (2020)', 'differential_corrections solver introduced in PHOEBE')
 
 
         # check for presence of datasets that require PHOEBE releases
@@ -5560,10 +5557,10 @@ class Bundle(ParameterSet):
                 
         # provide any references from features
         if len(self.filter(context='feature', kind='gp_sklearn').features):
-            recs = _add_reason(recs, 'Kochoska et al.', 'sklearn GPs introduced in PHOEBE')
+            recs = _add_reason(recs, 'Conroy et al. (2020)', 'sklearn GPs introduced in PHOEBE')
             recs = _add_reason(recs, 'scikit-learn', 'scikit-learn for gaussian processes')
         if len(self.filter(context='feature', kind='gp_celerite2').features):
-            recs = _add_reason(recs, 'Kochoska et al.', 'celerite2 GPs introduced in PHOEBE')
+            recs = _add_reason(recs, 'Conroy et al. (2020)', 'celerite2 GPs introduced in PHOEBE')
             recs = _add_reason(recs, 'Foreman-Mackey et al., (2017)', 'celerite2 for gaussian processes')
         # provide references from dependencies
         recs = _add_reason(recs, 'numpy/scipy', 'numpy/scipy dependency within PHOEBE')

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -5431,8 +5431,9 @@ class Bundle(ParameterSet):
                          'Skilling (2006)': 'https://projecteuclid.org/euclid.ba/1340370944',
                          'Foreman-Mackey et al. (2017)': 'https://ui.adsabs.harvard.edu/abs/2017AJ....154..220F',
                          'Prsa et al. (2008)': 'https://ui.adsabs.harvard.edu/abs/2008ApJ...687..542P',
-                         'Kochoska et al. (in prep)': 'https://phoebe-project.org/publications/2022Kochoska+',
+                         'Kochoska et al.': 'https://phoebe-project.org/publications/2022Kochoska+',
                          'scikit-learn': 'https://scikit-learn.org/stable/about.html#citing-scikit-learn',
+                         'Jones et al. (2026)': 'https://phoebe-project.org/publications/2026Jones+',
                         }
 
         # ref: [reasons] pairs
@@ -5468,10 +5469,10 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'astropy', 'astropy.timeseries for periodograms')
             elif solver_kind in ['lc_geometry', 'rv_geometry']:
                 recs = _add_reason(recs, 'Conroy et al. (2020)', '{} solver initially introduced in PHOEBE'.format(solver_kind))
-                recs = _add_reason(recs, 'Kochoska et al. (in prep)', '{} solver updates'.format(solver_kind))
+                recs = _add_reason(recs, 'Kochoska et al.', '{} solver updates'.format(solver_kind))
             elif solver_kind == 'ebai':
                 recs = _add_reason(recs, 'Conroy et al. (2020)', 'ebai solver initially introduced in PHOEBE')
-                recs = _add_reason(recs, 'Kochoska et al. (in prep)', 'ebai solver updates')
+                recs = _add_reason(recs, 'Kochoska et al.', 'ebai solver updates')
                 ebai_method = self.get_value(qualifier='ebai_method', solver=solver, **_skip_filter_checks)
                 if solver_kind == 'knn':
                     recs = _add_reason(recs, 'scikit-learn', 'knn implementation for ebai solver')
@@ -5488,10 +5489,10 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Skilling (2004)', 'nested sampling: dynesty solver backend')
                 recs = _add_reason(recs, 'Skilling (2006)', 'nested sampling: dynesty solver backend')
             elif solver_kind == 'differential_evolution':
-                recs = _add_reason(recs, 'Kochoska et al. (in prep)', 'differential_evolution solver introduced in PHOEBE')
+                recs = _add_reason(recs, 'Kochoska et al.', 'differential_evolution solver introduced in PHOEBE')
                 recs = _add_reason('numpy/scipy', '{} solver uses scipy.optimize.differential_evolution'.format(solver_kind))
             elif solver_kind == 'differential_corrections':
-                recs = _add_reason(recs, 'Kochoska et al. (in prep)', 'differential_corrections solver introduced in PHOEBE')
+                recs = _add_reason(recs, 'Kochoska et al.', 'differential_corrections solver introduced in PHOEBE')
 
 
         # check for presence of datasets that require PHOEBE releases
@@ -5520,14 +5521,19 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Castelli & Kurucz (2004)', 'ck2004 atmosphere tables')
             elif atmname == 'phoenix':
                 recs = _add_reason(recs, 'Husser et al. (2013)', 'phoenix atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname == 'tmap_sdO':
                 recs = _add_reason(recs, 'Reindl et al. (2016)', 'TMAP atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname in ['tmap_DA', 'tmap_DAO', 'tmap_DO']:
                 recs = _add_reason(recs, 'Reindl et al. (2023)', 'TMAP atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname in ['extern_planckint', 'extern_atmx']:
                 recs = _add_reason(recs, 'Prsa & Zwitter (2005)', '{} atmosphere tables'.format(atmname))
             elif atmname == 'tremblay':
                 recs = _add_reason(recs, 'Tremblay et al. (2011, 2013)', 'Tremblay atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+
 
         for atm_param in self.filter(qualifier='ld_coeffs_source', component=self.hierarchy.get_stars()).to_list():
             atmname = atm_param.get_value()
@@ -5535,19 +5541,29 @@ class Bundle(ParameterSet):
                 recs = _add_reason(recs, 'Castelli & Kurucz (2004)', 'ck2004 atmosphere tables for limb-darkening interpolation')
             elif atmname == 'phoenix':
                 recs = _add_reason(recs, 'Husser et al. (2013)', 'phoenix atmosphere tables for limb-darkening interpolation')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname == 'tmap_sdO':
                 recs = _add_reason(recs, 'Reindl et al. (2016)', 'TMAP atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname in ['tmap_DA', 'tmap_DAO', 'tmap_DO']:
                 recs = _add_reason(recs, 'Reindl et al. (2023)', 'TMAP atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
             elif atmname == 'tremblay':
                 recs = _add_reason(recs, 'Tremblay et al. (2011, 2013)', 'Tremblay atmosphere tables')
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'phoenix atmosphere tables included in PHOEBE')
+
+        # cite extrapolation/blending methods when atmosphere grids are used off-grid
+        for extrap_param in self.filter(qualifier=['atm_extrapolation_method', 'ld_extrapolation_method'], compute=computes).to_list():
+            if extrap_param.get_value() != 'none':
+                recs = _add_reason(recs, 'Jones et al. (2026)', 'atmosphere extrapolation/blending')
+                break
                 
         # provide any references from features
         if len(self.filter(context='feature', kind='gp_sklearn').features):
-            recs = _add_reason(recs, 'Kochoska et al. (in prep)', 'sklearn GPs introduced in PHOEBE')
+            recs = _add_reason(recs, 'Kochoska et al.', 'sklearn GPs introduced in PHOEBE')
             recs = _add_reason(recs, 'scikit-learn', 'scikit-learn for gaussian processes')
         if len(self.filter(context='feature', kind='gp_celerite2').features):
-            recs = _add_reason(recs, 'Kochoska et al. (in prep)', 'celerite2 GPs introduced in PHOEBE')
+            recs = _add_reason(recs, 'Kochoska et al.', 'celerite2 GPs introduced in PHOEBE')
             recs = _add_reason(recs, 'Foreman-Mackey et al., (2017)', 'celerite2 for gaussian processes')
         # provide references from dependencies
         recs = _add_reason(recs, 'numpy/scipy', 'numpy/scipy dependency within PHOEBE')

--- a/phoebe/parameters/parameters.py
+++ b/phoebe/parameters/parameters.py
@@ -3046,7 +3046,7 @@ class ParameterSet(object):
 
         Returns
         ---------
-        * (<phoebe.parameters.Parameter, bool): the Parameter object (either
+        * (<phoebe.parameters.Parameter>, bool): the Parameter object (either
             from filtering or newly created) and a boolean telling whether the
             Parameter was created or not.
 

--- a/phoebe/parameters/system.py
+++ b/phoebe/parameters/system.py
@@ -24,7 +24,7 @@ def system(**kwargs):
 
     Returns
     --------
-    * (<phoebe.parameters.ParameterSet) ParameterSet of all created Parameters.
+    * (<phoebe.parameters.ParameterSet>) ParameterSet of all created Parameters.
     """
     params = []
     constraints = []


### PR DESCRIPTION
currently pointing to the not-yet-live landing page on phoebe docs.  Once the publication is actually live, we can replace with a link to ADS (in whatever is the next bugfix after that).

**NOTE**: I also updated the Kochoska in prep citations since that paper is no longer planned, but wondering if we should either remove those or point them to this paper instead?  Or we can flesh out the page that it points to on the website with some information (but ultimately there is no DOI able to be cited, so we should probably give some guidance on what if anything to cite, or just remove those entries entirely to fallback on the original phoebe paper(s)).