### PR TITLE
blending_factors/extrapolation_dists map to nans after vert>face

### DIFF
--- a/phoebe/backend/backends.py
+++ b/phoebe/backend/backends.py
@@ -1442,6 +1442,11 @@ class PhoebeBackend(BaseBackendByTime):
 
                             value = body.mesh[key].centers
 
+                            if indep in ['blending_factors', 'extrapolation_dists']:
+                                # Apply on-grid masking at face-level so partially
+                                # off-grid faces are retained after vertex averaging.
+                                value[value == 0] = np.nan
+
                             if indep in ['intensities', 'abs_intensities']:
                                 # replace elements in the back with nan (these
                                 # were computed internally with abs(mus) to

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -1935,13 +1935,13 @@ class Star(Body):
             abs_intensities = abs_intens_results.get_interpolated_values()
             blending_factors = abs_intens_results.get_bfs()
             if blending_factors is not None:
-                blending_factors[blending_factors == 0] = np.nan
+                blending_factors = blending_factors.copy()
             else:
                 blending_factors = np.full(abs_intensities.shape[0], np.nan)
 
             extrapolation_dists = abs_intens_results.get_distances()
             if extrapolation_dists is not None:
-                extrapolation_dists[extrapolation_dists == 0] = np.nan
+                extrapolation_dists = extrapolation_dists.copy()
             else:
                 extrapolation_dists = np.full(abs_intensities.shape[0], np.nan)
 


### PR DESCRIPTION
This PR changes when zeros are mapped to nans for the mesh-exposed values for blending_factors and extrapolation_dists to be _after_ averaging the vertex values into a face-value.  Previously, a zero for any vertex (no extrapolation) would map to nan (no extrapolation) for the entire face because we were mapping zeros to nans before getting the element central value.

Note that estimating which triangles should have extrapolation/blending based on any input parameter to atmospheres (temperature, logg, etc) may not yield the same number of triangles as it is possible that the central value of a triangle is within bounds, even though one of the vertices was not.

In other words:

```
extrapolation method = linear
   N teff < 3500: 52
   N extrapolated: 67
   N blended: 67
```

does make sense, as the remaining 15 triangles had an "average" temperature in-bounds, but at least one vertex had a temperature (or potentially some other atmosphere parameter) out-of-bounds.