### PR TITLE
fixes array dimensionality quirk in legacy passband generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /phoebe/atmospheres/tables/tlusty
 /tests/tests/test_passbands/tables
 /tests/benchmark/results
+/tests/local
 MANIFEST
 *checkme*
 *_tmp*

--- a/phoebe/atmospheres/passbands.py
+++ b/phoebe/atmospheres/passbands.py
@@ -614,9 +614,10 @@ class Passband:
             if f'{atm.name}:Inorm' in self.content:
                 if export_to_pre25 and atm.name == 'blackbody':
                     teffs = self.ndp['blackbody'].axes[0]
-                    log10ints = self.ndp['blackbody'].table['inorm@energy']['grid']
+                    # Legacy BB_FUNC expects 1D teff-intensity arrays.
+                    log10ints = np.squeeze(self.ndp['blackbody'].table['inorm@energy']['grid'])
                     bb_func_energy = interpolate.splrep(teffs, log10ints, s=0)
-                    log10ints = self.ndp['blackbody'].table['inorm@photon']['grid']
+                    log10ints = np.squeeze(self.ndp['blackbody'].table['inorm@photon']['grid'])
                     bb_func_photon = interpolate.splrep(teffs, log10ints, s=0)
 
                     bb_func = Table({'teff': bb_func_energy[0], 'logi_e': bb_func_energy[1], 'logi_p': bb_func_photon[1]}, meta={'extname': 'BB_FUNC'})


### PR DESCRIPTION
When exporting to pre-2.5 passband format, blackbody grid had to be squeezed before fitting a spline; fixed.

tests/local sneaked into .gitignore to reduce chatter.