### PR TITLE
fixes a segfault when distortion_method='none' for both components

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ CHANGELOG
 * Fix bug where solvers would raise an error if the lnpriors calculation fails (due to parameter out of bounds or failed constraints).  This now correctly returns an lnprior of -inf. [#1171]
 * Fixes bug where passbands would not automatically download missing blackbody tables when blending is enabled. [#1168]
 * Fixes calculate_lnlikelihood when mesh datasets are included in the referenced model. [#1172]
+* Fixes a segfault when distortion_method='none' for both components. [#1170]
 
 ### 2.5.3
 

--- a/phoebe/backend/universe.py
+++ b/phoebe/backend/universe.py
@@ -350,6 +350,19 @@ class System(object):
             abs_normal_intensities = sigma_sb.value * body.mesh.teffs.for_computations**4 / np.pi  # bolometric intensities
             fluxes_intrins_per_body.append(abs_normal_intensities * np.pi)
 
+        if not len(fluxes_intrins_per_body):
+            # no body has a mesh (distortion_method='none' for all components),
+            # so there is nothing to irradiate.  Without this the per-body lists
+            # below are all-None while ld_func_and_coeffs is not, and libphoebe
+            # dereferences those Nones as arrays and segfaults.
+            logger.info("skipping reflection because no bodies have meshes")
+            return
+
+        # NOTE: the lists below are only consistent with each other because a
+        # system can have at most two meshables and any body without a mesh is
+        # caught by one of the two early returns.  Should support for more than
+        # two meshables ever be added, these will need to be filtered on
+        # body.mesh is not None.
         fluxes_intrins_flat = meshes.pack_column_flat(fluxes_intrins_per_body)
 
         if len(fluxes_intrins_per_body) == 1 and np.all([body.is_convex for body in self.bodies]):

--- a/phoebe/frontend/bundle.py
+++ b/phoebe/frontend/bundle.py
@@ -4293,6 +4293,44 @@ class Bundle(ParameterSet):
                                     self.filter(qualifier='mesh_method', compute=compute, force_ps=True, check_default=True, check_visible=False).to_list()+addl_parameters,
                                     True, 'run_compute')
 
+            # distortion_method='none' builds no mesh for that component, so it
+            # can neither contribute flux nor act as the luminosity reference
+            if compute_kind == 'phoebe':
+                distortion_method_params = self.filter(qualifier='distortion_method', compute=compute, context='compute', **_skip_filter_checks).to_list()
+                meshables = self.hierarchy.get_meshables()
+                # NOTE: mesh_method='wd' ignores distortion_method and always
+                # meshes as roche (see universe.System.from_bundle), so a stale
+                # 'none' left over from marching must not be flagged here
+                meshless_components = [p.component for p in distortion_method_params
+                                       if p.component in meshables and
+                                       p.get_value(distortion_method=kwargs.get('distortion_method', None)) == 'none' and
+                                       self.get_value(qualifier='mesh_method', component=p.component, compute=compute, context='compute', mesh_method=kwargs.get('mesh_method', None), default='marching', **_skip_filter_checks) != 'wd']
+
+                if len(meshless_components):
+                    # datasets whose synthetics require integrating over a mesh
+                    # (dynamical RVs and orbits do not, so they remain valid)
+                    mesh_dependent_datasets = self.filter(dataset=compute_enabled_datasets, kind=['lc', 'lp', 'mesh'], context='dataset', **_skip_filter_checks).datasets
+                    mesh_dependent_datasets += [ds for ds in self.filter(dataset=compute_enabled_datasets, kind='rv', context='dataset', **_skip_filter_checks).datasets
+                                                if 'flux-weighted' in [p.get_value(rv_method=kwargs.get('rv_method', None)) for p in
+                                                                       self.filter(qualifier='rv_method', compute=compute, dataset=ds, context='compute', **_skip_filter_checks).to_list()]]
+
+                    if len(mesh_dependent_datasets):
+                        if not len([c for c in meshables if c not in meshless_components]):
+                            report.add_item(self,
+                                            "distortion_method='none' for all components in compute='{}', so no mesh is created and datasets {} cannot be computed.".format(compute, mesh_dependent_datasets),
+                                            distortion_method_params+addl_parameters,
+                                            True, 'run_compute')
+                        else:
+                            for pblum_component_param in self.filter(qualifier='pblum_component', dataset=mesh_dependent_datasets, context='dataset', **_skip_filter_checks).to_list():
+                                dataset = pblum_component_param.dataset
+                                if self.get_value(qualifier='pblum_mode', dataset=dataset, context='dataset', **_skip_filter_checks) != 'component-coupled':
+                                    continue
+                                if pblum_component_param.get_value() in meshless_components:
+                                    report.add_item(self,
+                                                    "pblum_component='{}' for dataset='{}' has distortion_method='none' in compute='{}', so it has no luminosity to couple to and all fluxes would be scaled to zero.".format(pblum_component_param.get_value(), dataset, compute),
+                                                    [pblum_component_param]+distortion_method_params+addl_parameters,
+                                                    True, 'run_compute')
+
             # estimate if any body is smaller than any other body's triangles, using a spherical assumption
             if compute_kind=='phoebe' and 'wd' not in mesh_methods:
                 eclipse_method = self.get_value(qualifier='eclipse_method', compute=compute, eclipse_method=kwargs.get('eclipse_method', None), **_skip_filter_checks)

--- a/tests/tests/test_distortion_method_none/test_distortion_method_none.py
+++ b/tests/tests/test_distortion_method_none/test_distortion_method_none.py
@@ -1,7 +1,11 @@
 """
 """
 
+import numpy as np
+import pytest
+
 import phoebe
+
 
 def test_binary(plot=False):
     b = phoebe.Bundle.default_binary()
@@ -11,14 +15,129 @@ def test_binary(plot=False):
     b.add_dataset('mesh', compute_times=[0])
 
     for comp in ['primary', 'secondary']:
+        other = 'secondary' if comp == 'primary' else 'primary'
+
         b.set_value_all('distortion_method', value='roche')
         b.set_value('distortion_method', component=comp, value='none')
+
+        # the luminosity reference must be a component that actually has a
+        # mesh, otherwise every flux is scaled by pblum/0.0 -> 0.0
+        b.set_value_all('pblum_component', value=other)
+
         b.compute_pblums(pblum_method='stefan-boltzmann')
         b.compute_pblums()
 
         b.run_compute()
 
+        fluxes = b.get_value(qualifier='fluxes', context='model')
+        assert np.all(np.isfinite(fluxes))
+        assert np.all(fluxes > 0)
+
+
+def test_all_none_raises():
+    # no component has a mesh, so there is nothing to integrate over and the
+    # fluxes would come back as nans
+    b = phoebe.Bundle.default_binary()
+    b.add_dataset('lc', times=[0])
+    b.set_value_all('distortion_method', value='none')
+
+    report = b.run_checks_compute()
+    assert not report.passed
+
+    with pytest.raises(ValueError):
+        b.run_compute()
+
+
+def test_all_none_skip_checks_does_not_segfault():
+    # regression test for the reflection code passing all-None per-body arrays
+    # on to libphoebe (which dereferenced them as arrays and killed the kernel).
+    # run_checks catches this case, so bypass it to exercise the backend guard.
+    b = phoebe.Bundle.default_binary()
+    b.add_dataset('lc', times=[0])
+    b.set_value_all('distortion_method', value='none')
+
+    assert b.get_value(qualifier='irrad_method', context='compute') != 'none'
+
+    b.run_compute(skip_checks=True)
+
+    # nothing has a mesh, so there is no flux to be had -- the point of this
+    # test is purely that we get here at all rather than dying in libphoebe
+    assert len(b.get_value(qualifier='fluxes', context='model')) == 1
+
+
+def test_pblum_component_none_raises():
+    # pblum_component defaults to 'primary', which here has no mesh and so no
+    # luminosity to couple to -- every flux would be silently scaled to zero
+    b = phoebe.Bundle.default_binary()
+    b.add_dataset('lc', times=[0])
+    b.set_value('distortion_method', component='primary', value='none')
+
+    assert b.get_value(qualifier='pblum_mode', context='dataset') == 'component-coupled'
+    assert b.get_value(qualifier='pblum_component', context='dataset') == 'primary'
+
+    with pytest.raises(ValueError):
+        b.run_compute()
+
+    # ...but pointing pblum at the component that does have a mesh is fine
+    b.set_value_all('pblum_component', value='secondary')
+    b.run_compute()
+
+    fluxes = b.get_value(qualifier='fluxes', context='model')
+    assert np.all(np.isfinite(fluxes))
+    assert np.all(fluxes > 0)
+
+
+def test_pblum_decoupled_none_ok():
+    # decoupled scales each component independently, so a meshless component
+    # does not drag the other one to zero
+    b = phoebe.Bundle.default_binary()
+    b.add_dataset('lc', times=[0])
+    b.set_value('distortion_method', component='primary', value='none')
+    b.set_value_all('pblum_mode', value='decoupled')
+
+    b.run_compute()
+
+    fluxes = b.get_value(qualifier='fluxes', context='model')
+    assert np.all(np.isfinite(fluxes))
+    assert np.all(fluxes > 0)
+
+
+def test_stale_none_with_wd_meshing_ok():
+    # mesh_method='wd' ignores distortion_method and always meshes as roche, so
+    # a 'none' left behind from marching must not trip the checks above
+    phoebe.devel_on()  # required for wd meshing
+    try:
+        b = phoebe.Bundle.default_binary()
+        b.add_dataset('lc', times=[0])
+        b.set_value_all('distortion_method', value='none')  # while still visible
+        b.set_value_all('mesh_method', value='wd')
+
+        assert b.run_checks_compute().passed
+    finally:
+        phoebe.devel_off()  # reset for future tests
+
+
+def test_all_none_dynamical_rv_ok():
+    # dynamical RVs need no mesh at all, so distortion_method='none' everywhere
+    # must remain a valid (if unusual) configuration
+    b = phoebe.Bundle.default_binary()
+    b.add_dataset('rv', times=[0, 0.25])
+    b.set_value_all('distortion_method', value='none')
+    b.set_value_all('rv_method', value='dynamical')
+
+    b.run_compute()
+
+    for comp in ['primary', 'secondary']:
+        rvs = b.get_value(qualifier='rvs', component=comp, context='model')
+        assert np.all(np.isfinite(rvs))
+
 
 if __name__ == '__main__':
     logger = phoebe.logger(clevel='INFO')
     test_binary(plot=True)
+    test_all_none_raises()
+    test_all_none_skip_checks_does_not_segfault()
+    test_pblum_component_none_raises()
+    test_pblum_decoupled_none_ok()
+    test_stale_none_with_wd_meshing_ok()
+    test_all_none_dynamical_rv_ok()


### PR DESCRIPTION
The issue was in passing non-meshed arrays to libphoebe for reflection, which caused a segfault. This is now fixed on two levels: run_checks() now verifies whether bodies have associated fluxes, and python-side reflection now checks whether distortion method warrants reflection computation. While at it, Claude was kind enough to write a test suite for this so that we are regression-proof.